### PR TITLE
Fix automation loop and config typo

### DIFF
--- a/game.js
+++ b/game.js
@@ -59,6 +59,7 @@ function gameLoop() {
         checkPopulationGrowth();
         checkForEvents();
     }
+    runAutomation();
     updateActiveEvents();
     checkSurvival();
     updateDisplay();
@@ -90,7 +91,6 @@ function resetGame() {
         stone: 0,
         knowledge: 0,
         population: 1,
-        unassignedPopulation: 0,
         day: 1,
         time: 0,
         craftedItems: {},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "automation.js",
   "scripts": {
-    "start": "http-server -o" ,
+    "start": "http-server -o",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/resources.js
+++ b/resources.js
@@ -103,11 +103,13 @@ export function produceResources() {
 }
 
 export function checkPopulationGrowth() {
-    if (gameState.food >= CONSTANTS.POPULATION_THRESHOLD && gameState.water >= CONSTANTS.POPULATION_THRESHOLD) {
+    const config = getConfig();
+    const threshold = config.constants.POPULATION_THRESHOLD;
+    if (gameState.food >= threshold && gameState.water >= threshold) {
         gameState.population += 1;
         gameState.availableWorkers += 1;
-        gameState.food -= CONSTANTS.POPULATION_THRESHOLD;
-        gameState.water -= CONSTANTS.POPULATION_THRESHOLD;
+        gameState.food -= threshold;
+        gameState.water -= threshold;
         logEvent("The population has grown! You have a new available worker.");
         updateAutomationControls();
     }


### PR DESCRIPTION
## Summary
- ensure automated production runs during the game loop
- remove unused population field
- clean up start script spacing

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6848c004c66c832099da06e01bfda73d