### PR TITLE
Add progress overlay to harvest buttons

### DIFF
--- a/game.js
+++ b/game.js
@@ -35,19 +35,19 @@ function createGatheringActions(resources) {
 
         const button = document.createElement('button');
         button.id = `gather-${resource}`;
-        button.textContent = `Gather ${resource.charAt(0).toUpperCase() + resource.slice(1)}`;
-        button.addEventListener('click', () => gatherResource(resource));
-
-        const progressBarContainer = document.createElement('div');
-        progressBarContainer.className = 'progress-bar-container';
+        button.className = 'progress-button';
+        const textSpan = document.createElement('span');
+        textSpan.textContent = `Gather ${resource.charAt(0).toUpperCase() + resource.slice(1)}`;
+        button.appendChild(textSpan);
 
         const progressBar = document.createElement('div');
         progressBar.id = `${resource}-progress-bar`;
         progressBar.className = 'progress-bar';
+        button.appendChild(progressBar);
 
-        progressBarContainer.appendChild(progressBar);
+        button.addEventListener('click', () => gatherResource(resource));
+
         gatherAction.appendChild(button);
-        gatherAction.appendChild(progressBarContainer);
         actionsContainer.appendChild(gatherAction);
     });
 }

--- a/resources.js
+++ b/resources.js
@@ -12,7 +12,7 @@ export function gatherResource(resource) {
     }
 
     const button = document.getElementById(`gather-${resource}`);
-    const progressBar = document.getElementById(`${resource}-progress-bar`);
+    const progressBar = button.querySelector('.progress-bar');
     
     if (button.disabled) return;  // If already gathering, do nothing
     

--- a/styles.css
+++ b/styles.css
@@ -124,6 +124,26 @@ progress {
     transition: width 0.1s ease-in-out;
 }
 
+/* Progress bar overlay inside buttons */
+.progress-button {
+    position: relative;
+    overflow: hidden;
+}
+
+.progress-button .progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background-color: rgba(39, 174, 96, 0.5);
+    z-index: 0;
+}
+
+.progress-button span {
+    position: relative;
+    z-index: 1;
+}
+
 #crafting-queue {
     margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- embed progress bars directly in gather buttons for better mobile display
- adjust logic to update progress bar in new structure
- style buttons with overlay progress indicator

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c85d3048320b2ace2f647b70166