### PR TITLE
Fix gather/craft tab visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -344,7 +344,7 @@ progress::-moz-progress-bar {
     border-top: 1px solid #7f8c8d;
     margin: 20px 0;
 }
-#actions {
+#actions.game-section-active {
     display: grid;
     grid-template-columns: 1fr 1fr; /* Two columns for better organization */
     gap: 15px;
@@ -452,7 +452,7 @@ progress::-moz-progress-bar {
         gap: 5px;
     }
 
-    #actions {
+    #actions.game-section-active {
         grid-template-columns: 1fr;
         gap: 10px;
     }


### PR DESCRIPTION
## Summary
- hide gathering actions until the tab is selected

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a661b13748320950663dde83c0fa8