### PR TITLE
Add settings menu and shorter labels

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,5 +1,5 @@
 import { gameState, loadGameConfig, getConfig } from './gameState.js';
-import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup } from './ui.js';
+import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu } from './ui.js';
 import { gatherResource, consumeResources, produceResources, checkPopulationGrowth, study } from './resources.js';
 import { updateCraftableItems, processQueue } from './crafting.js';
 import { updateAutomationControls, runAutomation } from './automation.js';
@@ -20,6 +20,8 @@ async function initializeGame() {
     document.getElementById('study').addEventListener('click', study);
     document.getElementById('submit-puzzle').addEventListener('click', submitUnlockPuzzleAnswer);
     document.getElementById('close-puzzle').addEventListener('click', closePuzzlePopup);
+    document.getElementById('settings-btn').addEventListener('click', openSettingsMenu);
+    document.getElementById('close-settings').addEventListener('click', closeSettingsMenu);
 
     // Bottom navigation
     document.querySelectorAll('#bottom-nav .nav-btn').forEach(btn => {

--- a/index.html
+++ b/index.html
@@ -12,18 +12,18 @@
 </head>
 <body>
     <div id="game-container">
-        <h1>Advanced Survival and Civilization Rebuilder</h1>
         <div id="top-section">
+            <button id="settings-btn"><i class="fas fa-ellipsis-v"></i></button>
             <div id="day-night-cycle">
                 <span>Day: <span id="day-count">1</span> | Time: <span id="time-emoji">🌅</span> <span id="time-display">00:00</span></span>
                 <div id="population">
                     <div class="population-info">
                         <i class="fas fa-users"></i>
-                        <p>Population: <span id="population-count">1</span></p>
+                        <p>Pop: <span id="population-count">1</span></p>
                     </div>
                     <div class="population-info">
                         <i class="fas fa-user-tie"></i>
-                        <p>Available Workers: <span id="available-workers">1</span></p>
+                        <p>Workers: <span id="available-workers">1</span></p>
                     </div>
                 </div>
             </div>
@@ -86,6 +86,12 @@
         <input type="text" id="puzzle-answer" placeholder="Enter your answer">
         <button id="submit-puzzle">Submit Answer</button>
         <button id="close-puzzle">Close</button>
+    </div>
+
+    <div id="settings-menu" class="popup">
+        <h2>Settings</h2>
+        <p id="game-title">Advanced Survival and Civilization Rebuilder</p>
+        <button id="close-settings">Close</button>
     </div>
 
     <script type="module" src="game.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,29 @@ p, li {
     z-index: 50;
     background-color: #1e1e2f;
     padding-top: 10px;
+    padding-right: 40px; /* space for settings button */
+}
+
+#settings-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+#settings-menu {
+    display: none;
+    position: absolute;
+    top: 40px;
+    right: 10px;
+    background-color: #34495e;
+    padding: 10px;
+    border-radius: 5px;
+    z-index: 1000;
 }
 
 

--- a/ui.js
+++ b/ui.js
@@ -87,3 +87,11 @@ export function submitUnlockPuzzleAnswer() {
 export function closePuzzlePopup() {
     document.getElementById('puzzle-popup').style.display = 'none';
 }
+
+export function openSettingsMenu() {
+    document.getElementById('settings-menu').style.display = 'block';
+}
+
+export function closeSettingsMenu() {
+    document.getElementById('settings-menu').style.display = 'none';
+}


### PR DESCRIPTION
## Summary
- shorten population & worker labels to save space
- remove header from top of page
- add a settings menu accessible from a new ellipsis button
- wire up basic open/close logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a6ce178d8832089576de234f92957