### PR TITLE
Add navigation controls and gating for book

### DIFF
--- a/book.js
+++ b/book.js
@@ -5,27 +5,35 @@ import { updateCraftableItems } from './crafting.js';
 export function initBook() {
     document.getElementById('book-submit').addEventListener('click', submitAnswer);
     document.getElementById('book-next').addEventListener('click', nextPage);
+    document.getElementById('book-prev').addEventListener('click', prevPage);
     renderPage();
 }
 
-function getLockedItems() {
+function getItems() {
     const config = getConfig();
-    return config.items.filter(item => !gameState.unlockedFeatures.includes(item.id));
+    return config.items;
 }
 
 function getCurrentItem() {
-    const items = getLockedItems();
+    const items = getItems();
     return items[gameState.currentBookIndex] || null;
 }
 
 export function renderPage() {
+    const items = getItems();
     const item = getCurrentItem();
     const questionDiv = document.getElementById('book-question');
     const infoDiv = document.getElementById('book-item-info');
+    const prevBtn = document.getElementById('book-prev');
+    const nextBtn = document.getElementById('book-next');
+
+    prevBtn.disabled = gameState.currentBookIndex === 0;
+
     if (!item) {
         questionDiv.style.display = 'none';
         infoDiv.style.display = 'block';
         infoDiv.innerHTML = '<p>All pages unlocked!</p>';
+        nextBtn.disabled = true;
         return;
     }
     if (gameState.unlockedFeatures.includes(item.id)) {
@@ -38,11 +46,13 @@ export function renderPage() {
                 .join('');
             if (list) infoDiv.innerHTML += list;
         }
+        nextBtn.disabled = gameState.currentBookIndex >= items.length - 1;
     } else {
         infoDiv.style.display = 'none';
         questionDiv.style.display = 'block';
         document.getElementById('book-puzzle-text').textContent = item.puzzle;
         document.getElementById('book-answer').value = '';
+        nextBtn.disabled = true;
     }
 }
 
@@ -62,9 +72,16 @@ function submitAnswer() {
 }
 
 function nextPage() {
-    const items = getLockedItems();
+    const items = getItems();
     if (gameState.currentBookIndex < items.length - 1) {
         gameState.currentBookIndex++;
+        renderPage();
+    }
+}
+
+function prevPage() {
+    if (gameState.currentBookIndex > 0) {
+        gameState.currentBookIndex--;
         renderPage();
     }
 }

--- a/index.html
+++ b/index.html
@@ -66,7 +66,10 @@
                 </div>
                 <div id="book-item-info" style="display:none;"></div>
             </div>
-            <button id="book-next" class="book-nav">&rarr;</button>
+            <div id="book-nav-container">
+                <button id="book-prev" class="book-nav">&larr;</button>
+                <button id="book-next" class="book-nav">&rarr;</button>
+            </div>
         </div>
         <div id="crafting" class="game-section">
             <h2>Crafting</h2>

--- a/styles.css
+++ b/styles.css
@@ -190,6 +190,12 @@ progress {
     margin-top: 10px;
 }
 
+#book-nav-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
 /* Progress bar overlay inside buttons */
 .progress-button {
     position: relative;


### PR DESCRIPTION
## Summary
- add prev/next nav controls to book section
- show info after puzzle solved and enable next button
- disable moving forward until puzzle solved

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a7aee5c9483208e1bb5eda5e974a3