### PR TITLE
Fix book start and add item history

### DIFF
--- a/book.js
+++ b/book.js
@@ -3,6 +3,7 @@ import { updateDisplay } from './ui.js';
 import { updateCraftableItems } from './crafting.js';
 
 export function initBook() {
+    gameState.currentBookIndex = 0;
     document.getElementById('book-submit').addEventListener('click', submitAnswer);
     document.getElementById('book-next').addEventListener('click', nextPage);
     document.getElementById('book-prev').addEventListener('click', prevPage);
@@ -40,6 +41,12 @@ export function renderPage() {
         questionDiv.style.display = 'none';
         infoDiv.style.display = 'block';
         infoDiv.innerHTML = `<h3>${item.name}</h3><p>${item.description}</p>`;
+        if (item.history) {
+            infoDiv.innerHTML += `<p><strong>History:</strong> ${item.history}</p>`;
+        }
+        if (item.craftingInfo) {
+            infoDiv.innerHTML += `<p><strong>Real World Crafting:</strong> ${item.craftingInfo}</p>`;
+        }
         if (item.effect) {
             const list = Object.entries(item.effect)
                 .map(([k,v]) => `<div>${k}: ${v}</div>`)

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -440,6 +440,8 @@
       "id": "knife",
       "name": "Knife",
       "description": "A basic tool for various tasks",
+      "history": "Knives are among humanity's oldest tools, first fashioned from flint or obsidian in the Stone Age.",
+      "craftingInfo": "Shape a sharp stone or metal blade and secure it to a sturdy handle using fiber or sinew.",
       "requirements": {
         "stone": 5,
         "wood": 3,
@@ -457,6 +459,8 @@
       "id": "axe",
       "name": "Axe",
       "description": "Improves wood gathering efficiency",
+      "history": "Axes evolved from simple stone tools into metal-headed implements during the Bronze Age.",
+      "craftingInfo": "Bind a sharpened stone or metal head to a wooden handle, ensuring the head is secure for repeated swings.",
       "requirements": {
         "wood": 5,
         "stone": 5,
@@ -474,6 +478,8 @@
       "id": "shelter",
       "name": "Shelter",
       "description": "Reduces resource consumption",
+      "history": "From simple caves to wooden huts, shelters have protected humans from the elements since prehistory.",
+      "craftingInfo": "Construct a basic frame from branches or wood and cover it with thatch, hide, or cloth to keep out the weather.",
       "requirements": {
         "wood": 10,
         "stone": 5,
@@ -491,6 +497,8 @@
       "id": "pickaxe",
       "name": "Pickaxe",
       "description": "Allows efficient stone and ore gathering",
+      "history": "Metal pickaxes enabled miners to extract valuable minerals from rock, a cornerstone of ancient industry.",
+      "craftingInfo": "Forge a pointed metal head and attach it firmly to a wooden handle to concentrate force on a small area.",
       "requirements": {
         "wood": 8,
         "stone": 15,


### PR DESCRIPTION
## Summary
- ensure study book resets to the first page
- show history and real world crafting tips when an item is unlocked
- add history/crafting info for the first few items

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a7de3f410832098004ddc5f8d4aac