### PR TITLE
Implement worker training system

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { gameState, loadGameConfig, getConfig } from './gameState.js';
 import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu } from './ui.js';
-import { gatherResource, consumeResources, produceResources, checkPopulationGrowth } from './resources.js';
+import { gatherResource, consumeResources, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
 import { updateCraftableItems, processQueue } from './crafting.js';
 import { updateAutomationControls, runAutomation } from './automation.js';
 import { checkForEvents, updateActiveEvents } from './events.js';
@@ -23,6 +23,10 @@ async function initializeGame() {
     document.getElementById('close-puzzle').addEventListener('click', closePuzzlePopup);
     document.getElementById('settings-btn').addEventListener('click', openSettingsMenu);
     document.getElementById('close-settings').addEventListener('click', closeSettingsMenu);
+    const trainBtn = document.getElementById('train-worker-btn');
+    if (trainBtn) {
+        trainBtn.addEventListener('click', trainWorker);
+    }
 
     // Bottom navigation
     document.querySelectorAll('#bottom-nav .nav-btn').forEach(btn => {
@@ -106,10 +110,12 @@ function resetGame() {
         stone: 0,
         knowledge: 0,
         population: 1,
+        workers: 0,
         day: 1,
         time: 0,
         craftedItems: {},
-        automationAssignments: {}
+        automationAssignments: {},
+        availableWorkers: 0
     });
     updateDisplay();
     updateCraftableItems();

--- a/gameState.js
+++ b/gameState.js
@@ -6,7 +6,8 @@ export const gameState = {
     automationAssignments: {},
     currentWork: null,
     craftingQueue: [],
-    currentBookIndex: 0
+    currentBookIndex: 0,
+    workers: 0
 };
 
 export async function loadGameConfig() {
@@ -19,7 +20,7 @@ export async function loadGameConfig() {
         
         // Initialize gameState with values from config
         Object.assign(gameState, gameConfig.initialState);
-        gameState.availableWorkers = gameState.population;
+        gameState.availableWorkers = gameState.workers;
     } catch (error) {
         console.error("Failed to load game configuration:", error);
     }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,8 @@
                     </div>
                     <div class="population-info">
                         <i class="fas fa-user-tie"></i>
-                        <p>Workers: <span id="available-workers">1</span></p>
+                        <p>Workers: <span id="available-workers">0</span>/<span id="total-workers">0</span></p>
+                        <button id="train-worker-btn">Train</button>
                     </div>
                 </div>
             </div>

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -22,6 +22,7 @@
     "fruit": 0,
     "knowledge": 0,
     "population": 1,
+    "workers": 0,
     "day": 1,
     "time": 0
   },

--- a/resources.js
+++ b/resources.js
@@ -107,12 +107,28 @@ export function checkPopulationGrowth() {
     const threshold = config.constants.POPULATION_THRESHOLD;
     if (gameState.food >= threshold && gameState.water >= threshold) {
         gameState.population += 1;
-        gameState.availableWorkers += 1;
         gameState.food -= threshold;
         gameState.water -= threshold;
-        logEvent("The population has grown! You have a new available worker.");
+        logEvent("Your settlement has grown! Train newcomers to put them to work.");
         updateAutomationControls();
     }
+}
+
+export function trainWorker() {
+    if (gameState.population <= gameState.workers) {
+        logEvent("No untrained population available.");
+        return;
+    }
+    if (gameState.knowledge < 1) {
+        logEvent("Not enough knowledge to train a worker.");
+        return;
+    }
+    gameState.knowledge -= 1;
+    gameState.workers += 1;
+    gameState.availableWorkers += 1;
+    logEvent("Trained a new worker.");
+    updateAutomationControls();
+    updateDisplay();
 }
 
 function getKnowledgeGainMultiplier() {

--- a/ui.js
+++ b/ui.js
@@ -11,6 +11,7 @@ export function updateDisplay() {
     document.getElementById('water-bar').value = gameState.water;
     document.getElementById('population-count').textContent = gameState.population;
     document.getElementById('available-workers').textContent = gameState.availableWorkers;
+    document.getElementById('total-workers').textContent = gameState.workers;
     document.getElementById('day-count').textContent = gameState.day;
 }
 


### PR DESCRIPTION
## Summary
- introduce `workers` property in state and config
- add Train Worker button to UI
- add `trainWorker` action and adjust population growth
- hook up training in game initialization and reset
- display total trained workers alongside available workers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a868c908483209b0fff455b6fdd77