### PR TITLE
Fix crafting multipliers and display

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,5 +1,5 @@
 import { gameState, loadGameConfig, getConfig } from './gameState.js';
-import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu } from './ui.js';
+import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu, updateGatherButtons } from './ui.js';
 import { gatherResource, consumeResources, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
 import { updateCraftableItems, processQueue } from './crafting.js';
 import { updateAutomationControls, runAutomation } from './automation.js';
@@ -13,6 +13,7 @@ async function initializeGame() {
     updateCraftableItems();
     updateAutomationControls();
     createGatheringActions(config.resources);
+    updateGatherButtons();
     initBook();
 
     // Event listeners
@@ -57,6 +58,9 @@ function createGatheringActions(resources) {
         const textSpan = document.createElement('span');
         textSpan.textContent = `Gather ${resource.charAt(0).toUpperCase() + resource.slice(1)}`;
         button.appendChild(textSpan);
+        const multSpan = document.createElement('span');
+        multSpan.className = 'multiplier';
+        button.appendChild(multSpan);
 
         const progressBar = document.createElement('div');
         progressBar.id = `${resource}-progress-bar`;

--- a/resources.js
+++ b/resources.js
@@ -3,6 +3,18 @@ import { logEvent, updateDisplay, updateWorkingSection, showUnlockPuzzle } from 
 import { updateAutomationControls } from './automation.js';
 import { updateCraftableItems, areDependenciesMet } from './crafting.js';
 
+export function getGatheringMultiplier(resource) {
+    return Object.values(gameState.craftedItems).reduce((mult, item) => {
+        if (item.effect) {
+            const key = `${resource}GatheringMultiplier`;
+            if (item.effect[key]) {
+                mult *= item.effect[key];
+            }
+        }
+        return mult;
+    }, 1);
+}
+
 
 export function gatherResource(resource) {
     const config = getConfig();
@@ -42,9 +54,7 @@ export function gatherResource(resource) {
 function getGatheringTime(resource) {
     const config = getConfig();
     let time = config.gatheringTimes[resource];
-    if (resource === 'wood' && gameState.craftedItems.axe) {
-        time /= gameState.craftedItems.axe.effect.woodGatheringMultiplier;
-    }
+    time /= getGatheringMultiplier(resource);
     // Apply gathering efficiency modifier from events
     time /= (gameState.gatheringEfficiency || 1);
     // You can add more modifiers here based on other upgrades or skills
@@ -52,11 +62,8 @@ function getGatheringTime(resource) {
 }
 
 function completeGathering(resource) {
-    let amount = 1;
-    if (resource === 'wood' && gameState.craftedItems.axe) {
-        amount = gameState.craftedItems.axe.effect.woodGatheringMultiplier;
-    }
-    
+    let amount = getGatheringMultiplier(resource);
+
     // Apply gathering efficiency modifier
     amount *= (gameState.gatheringEfficiency || 1);
     

--- a/styles.css
+++ b/styles.css
@@ -201,6 +201,9 @@ progress {
     position: relative;
     overflow: hidden;
     padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .progress-button .progress-bar {
@@ -215,6 +218,10 @@ progress {
 .progress-button span {
     position: relative;
     z-index: 1;
+}
+
+.progress-button .multiplier {
+    margin-left: 8px;
 }
 
 #crafting-queue {

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,6 @@
 import { gameState, getConfig } from './gameState.js';
 import { updateCraftableItems } from './crafting.js';
+import { getGatheringMultiplier } from './resources.js';
 
 export function updateDisplay() {
     document.getElementById('food').textContent = Math.floor(gameState.food);
@@ -13,6 +14,7 @@ export function updateDisplay() {
     document.getElementById('available-workers').textContent = gameState.availableWorkers;
     document.getElementById('total-workers').textContent = gameState.workers;
     document.getElementById('day-count').textContent = gameState.day;
+    updateGatherButtons();
 }
 
 // Previously displayed current work progress. Section removed, so keep stub.
@@ -95,4 +97,20 @@ export function openSettingsMenu() {
 
 export function closeSettingsMenu() {
     document.getElementById('settings-menu').style.display = 'none';
+}
+
+export function updateGatherButtons() {
+    const config = getConfig();
+    config.resources.forEach(resource => {
+        const button = document.getElementById(`gather-${resource}`);
+        if (!button) return;
+        let multiplierSpan = button.querySelector('.multiplier');
+        if (!multiplierSpan) {
+            multiplierSpan = document.createElement('span');
+            multiplierSpan.className = 'multiplier';
+            button.appendChild(multiplierSpan);
+        }
+        const mult = getGatheringMultiplier(resource);
+        multiplierSpan.textContent = mult > 1 ? `x${mult}` : '';
+    });
 }


### PR DESCRIPTION
## Summary
- apply gathering multipliers from any crafted item
- show the multiplier beside each gather button
- style gather buttons with flex layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a887ff4c083208b49434e0983f138