### PR TITLE
Fix population growth trigger

### DIFF
--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -22,7 +22,7 @@
     "fruit": 0,
     "knowledge": 0,
     "population": 1,
-    "workers": 0,
+    "workers": 1,
     "day": 1,
     "time": 0
   },

--- a/resources.js
+++ b/resources.js
@@ -79,6 +79,7 @@ function completeGathering(resource) {
     updateDisplay();
     updateCraftableItems();
     updateWorkingSection();
+    checkPopulationGrowth();
 }
 
 
@@ -107,6 +108,8 @@ export function produceResources() {
     }
     gameState.food = Math.min(gameState.food, 100);
     gameState.water = Math.min(gameState.water, 100);
+    checkPopulationGrowth();
+    updateDisplay();
 }
 
 export function checkPopulationGrowth() {
@@ -118,6 +121,7 @@ export function checkPopulationGrowth() {
         gameState.water -= threshold;
         logEvent("Your settlement has grown! Train newcomers to put them to work.");
         updateAutomationControls();
+        updateDisplay();
     }
 }
 


### PR DESCRIPTION
## Summary
- trigger population growth when gathering and from automation
- refresh the display after population increases

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a8bf69d60832081322c6cf8be7f9b