### PR TITLE
Refine population growth logic

### DIFF
--- a/crafting.js
+++ b/crafting.js
@@ -87,6 +87,7 @@ function completeCrafting(item) {
     updateDisplay();
     updateWorkingSection();
     updateAutomationControls();
+    gameState.craftCount += 1;
 
     if (gameState.craftingQueue.length > 0) {
         processQueue();

--- a/game.js
+++ b/game.js
@@ -94,6 +94,7 @@ function updateTime() {
     gameState.time = (gameState.time + 1) % config.constants.DAY_LENGTH;
     if (gameState.time === 0) {
         gameState.day += 1;
+        gameState.daysSinceGrowth += 1;
     }
     updateTimeEmoji();
     updateTimeDisplay();
@@ -119,7 +120,11 @@ function resetGame() {
         time: 0,
         craftedItems: {},
         automationAssignments: {},
-        availableWorkers: 0
+        availableWorkers: 0,
+        gatherCount: 0,
+        studyCount: 0,
+        craftCount: 0,
+        daysSinceGrowth: 0
     });
     updateDisplay();
     updateCraftableItems();

--- a/gameState.js
+++ b/gameState.js
@@ -7,7 +7,11 @@ export const gameState = {
     currentWork: null,
     craftingQueue: [],
     currentBookIndex: 0,
-    workers: 0
+    workers: 0,
+    gatherCount: 0,
+    studyCount: 0,
+    craftCount: 0,
+    daysSinceGrowth: 0
 };
 
 export async function loadGameConfig() {

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -24,12 +24,21 @@
     "population": 1,
     "workers": 1,
     "day": 1,
-    "time": 0
+    "time": 0,
+    "gatherCount": 0,
+    "studyCount": 0,
+    "craftCount": 0,
+    "daysSinceGrowth": 0
   },
   "constants": {
     "DAY_LENGTH": 600,
     "DAY_PHASE": 300,
-    "POPULATION_THRESHOLD": 50
+    "POPULATION_THRESHOLD": 50,
+    "POPULATION_GROWTH_DAYS": 3,
+    "POPULATION_GATHER_REQUIRED": 5,
+    "POPULATION_STUDY_REQUIRED": 2,
+    "POPULATION_CRAFT_REQUIRED": 1,
+    "POPULATION_GROWTH_COST": 10
   },
   "gatheringTimes": {
     "wood": 5000,

--- a/resources.js
+++ b/resources.js
@@ -83,7 +83,7 @@ function completeGathering(resource) {
     updateDisplay();
     updateCraftableItems();
     updateWorkingSection();
-    checkPopulationGrowth();
+    gameState.gatherCount += 1;
 }
 
 
@@ -112,18 +112,29 @@ export function produceResources() {
     }
     gameState.food = Math.min(gameState.food, 100);
     gameState.water = Math.min(gameState.water, 100);
-    checkPopulationGrowth();
     updateDisplay();
 }
 
 export function checkPopulationGrowth() {
     const config = getConfig();
     const threshold = config.constants.POPULATION_THRESHOLD;
-    if (gameState.food >= threshold && gameState.water >= threshold) {
+    if (
+        gameState.food >= threshold &&
+        gameState.water >= threshold &&
+        gameState.daysSinceGrowth >= config.constants.POPULATION_GROWTH_DAYS &&
+        gameState.gatherCount >= config.constants.POPULATION_GATHER_REQUIRED &&
+        gameState.studyCount >= config.constants.POPULATION_STUDY_REQUIRED &&
+        gameState.craftCount >= config.constants.POPULATION_CRAFT_REQUIRED
+    ) {
         gameState.population += 1;
-        gameState.food -= threshold;
-        gameState.water -= threshold;
+        const cost = config.constants.POPULATION_GROWTH_COST;
+        gameState.food = Math.max(0, gameState.food - cost);
+        gameState.water = Math.max(0, gameState.water - cost);
         logEvent("Your settlement has grown! Train newcomers to put them to work.");
+        gameState.gatherCount = 0;
+        gameState.studyCount = 0;
+        gameState.craftCount = 0;
+        gameState.daysSinceGrowth = 0;
         updateAutomationControls();
         updateDisplay();
     }
@@ -215,6 +226,7 @@ export function study() {
                 showUnlockPuzzle(nextUnlock);
             }
             updateWorkingSection();
+            gameState.studyCount += 1;
         }
     }, interval); // Study time affected by research speed
 }


### PR DESCRIPTION
## Summary
- track counts for gathering, studying, crafting and time passed
- grow population only when minimum time and activity counts are met
- reduce food/water cost when population grows
- reset activity counters on growth or game reset

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a92eb14a08320a17e4da7298a5395