### PR TITLE
Add UI display for extra resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,26 @@
                 <i class="fas fa-book"></i>
                 <span id="knowledge">2</span>
             </div>
+            <div class="resource-item">
+                <i class="fas fa-cubes"></i>
+                <span id="clay">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-spa"></i>
+                <span id="fiber">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-gem"></i>
+                <span id="ore">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-leaf"></i>
+                <span id="herbs">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-apple-alt"></i>
+                <span id="fruit">0</span>
+            </div>
         </div>
         </div>
         <div id="actions" class="game-section game-section-active">

--- a/ui.js
+++ b/ui.js
@@ -8,6 +8,11 @@ export function updateDisplay() {
     document.getElementById('wood').textContent = Math.floor(gameState.wood);
     document.getElementById('stone').textContent = Math.floor(gameState.stone);
     document.getElementById('knowledge').textContent = Math.floor(gameState.knowledge);
+    document.getElementById('clay').textContent = Math.floor(gameState.clay);
+    document.getElementById('fiber').textContent = Math.floor(gameState.fiber);
+    document.getElementById('ore').textContent = Math.floor(gameState.ore);
+    document.getElementById('herbs').textContent = Math.floor(gameState.herbs);
+    document.getElementById('fruit').textContent = Math.floor(gameState.fruit);
     document.getElementById('food-bar').value = gameState.food;
     document.getElementById('water-bar').value = gameState.water;
     document.getElementById('population-count').textContent = gameState.population;


### PR DESCRIPTION
## Summary
- show clay, fiber, ore, herbs, and fruit in the resources panel
- update `updateDisplay` to render new resources in the UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b1110515c8320a1c7993e961dfd3d