### PR TITLE
Fix resource consumption timing

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { gameState, loadGameConfig, getConfig } from './gameState.js';
 import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu, updateGatherButtons } from './ui.js';
-import { gatherResource, consumeResources, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
+import { gatherResource, consumeResources, logDailyConsumption, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
 import { updateCraftableItems, processQueue } from './crafting.js';
 import { updateAutomationControls, runAutomation } from './automation.js';
 import { checkForEvents, updateActiveEvents } from './events.js';
@@ -76,8 +76,9 @@ function createGatheringActions(resources) {
 
 function gameLoop() {
     updateTime();
+    consumeResources(1);
     if (gameState.time === 0) { // Start of a new day
-        consumeResources();
+        logDailyConsumption();
         produceResources();
         checkPopulationGrowth();
         checkForEvents();
@@ -124,7 +125,9 @@ function resetGame() {
         gatherCount: 0,
         studyCount: 0,
         craftCount: 0,
-        daysSinceGrowth: 0
+        daysSinceGrowth: 0,
+        dailyFoodConsumed: 0,
+        dailyWaterConsumed: 0
     });
     updateDisplay();
     updateCraftableItems();

--- a/gameState.js
+++ b/gameState.js
@@ -12,7 +12,9 @@ export const gameState = {
     gatherCount: 0,
     studyCount: 0,
     craftCount: 0,
-    daysSinceGrowth: 0
+    daysSinceGrowth: 0,
+    dailyFoodConsumed: 0,
+    dailyWaterConsumed: 0
 };
 
 export async function loadGameConfig() {
@@ -27,6 +29,8 @@ export async function loadGameConfig() {
         Object.assign(gameState, gameConfig.initialState);
         gameState.availableWorkers = gameState.workers;
         gameState.automationProgress = {};
+        gameState.dailyFoodConsumed = 0;
+        gameState.dailyWaterConsumed = 0;
     } catch (error) {
         console.error("Failed to load game configuration:", error);
     }

--- a/resources.js
+++ b/resources.js
@@ -87,15 +87,26 @@ function completeGathering(resource) {
 }
 
 
-export function consumeResources() {
-    const consumptionRate = gameState.craftedItems.shelter ? 0.5 : 1;
-    const foodConsumption = Math.min(gameState.food, consumptionRate * gameState.population);
-    const waterConsumption = Math.min(gameState.water, consumptionRate * gameState.population);
-    
-    gameState.food -= foodConsumption;
-    gameState.water -= waterConsumption;
-    
-    logEvent(`Consumed ${foodConsumption.toFixed(1)} food and ${waterConsumption.toFixed(1)} water for the day.`);
+export function consumeResources(seconds = 1) {
+    const config = getConfig();
+    const dailyRate = gameState.craftedItems.shelter ? 0.5 : 1;
+    const ratePerSecond = (dailyRate * gameState.population) / config.constants.DAY_LENGTH;
+    const amount = ratePerSecond * seconds;
+
+    const foodConsumed = Math.min(gameState.food, amount);
+    const waterConsumed = Math.min(gameState.water, amount);
+
+    gameState.food -= foodConsumed;
+    gameState.water -= waterConsumed;
+
+    gameState.dailyFoodConsumed += foodConsumed;
+    gameState.dailyWaterConsumed += waterConsumed;
+}
+
+export function logDailyConsumption() {
+    logEvent(`Consumed ${gameState.dailyFoodConsumed.toFixed(1)} food and ${gameState.dailyWaterConsumed.toFixed(1)} water for the day.`);
+    gameState.dailyFoodConsumed = 0;
+    gameState.dailyWaterConsumed = 0;
 }
 
 


### PR DESCRIPTION
## Summary
- track daily food and water consumption
- consume resources each second
- log daily consumption totals at the start of each new day

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b5403f49c8320a1b7831797ea6581