### PR TITLE
Improve event system

### DIFF
--- a/events.js
+++ b/events.js
@@ -1,5 +1,5 @@
 import { gameState, getConfig } from './gameState.js';
-import { logEvent, updateDisplay } from './ui.js';
+import { logEvent, updateDisplay, showEventPopup } from './ui.js';
 
 let activeEvents = [];
 
@@ -14,7 +14,8 @@ export function checkForEvents() {
 
 function triggerEvent(event) {
     logEvent(`Event: ${event.name} - ${event.description}`);
-    
+    showEventPopup(event);
+
     Object.entries(event.effect).forEach(([key, value]) => {
         if (key in gameState) {
             gameState[key] += value;
@@ -25,7 +26,9 @@ function triggerEvent(event) {
     });
 
     if (event.duration) {
-        activeEvents.push({...event, remainingDuration: event.duration});
+        const config = getConfig();
+        const durationSeconds = event.duration * config.constants.DAY_LENGTH;
+        activeEvents.push({ ...event, remainingDuration: durationSeconds });
     }
 
     updateDisplay();

--- a/index.html
+++ b/index.html
@@ -129,6 +129,11 @@
         <button id="close-puzzle">Close</button>
     </div>
 
+    <div id="event-popup" class="popup">
+        <h2 id="event-name"></h2>
+        <p id="event-description"></p>
+    </div>
+
     <div id="settings-menu" class="popup">
         <h2>Settings</h2>
         <p id="game-title">Advanced Survival and Civilization Rebuilder</p>

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -452,6 +452,47 @@
       },
       "duration": 3,
       "probability": 0.06
+    },
+    {
+      "id": "drought",
+      "name": "Drought",
+      "description": "A severe drought reduces water supplies and slows gathering.",
+      "effect": {
+        "water": -30,
+        "gatheringEfficiency": 0.9
+      },
+      "duration": 3,
+      "probability": 0.05
+    },
+    {
+      "id": "bandit_raid",
+      "name": "Bandit Raid",
+      "description": "Bandits raid your settlement and steal resources.",
+      "effect": {
+        "food": -20,
+        "wood": -20
+      },
+      "probability": 0.04
+    },
+    {
+      "id": "traveling_merchant",
+      "name": "Traveling Merchant",
+      "description": "A wandering merchant offers useful supplies.",
+      "effect": {
+        "food": 20,
+        "stone": 20,
+        "knowledge": 2
+      },
+      "probability": 0.05
+    },
+    {
+      "id": "minor_earthquake",
+      "name": "Minor Earthquake",
+      "description": "An earthquake damages structures and costs some stone.",
+      "effect": {
+        "stone": -25
+      },
+      "probability": 0.03
     }
   ],
   "items": [

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,11 @@ progress {
     margin-top: 10px;
 }
 
+#event-popup {
+    min-width: 200px;
+    text-align: center;
+}
+
 .gather-action {
     display: flex;
     align-items: center;

--- a/ui.js
+++ b/ui.js
@@ -52,6 +52,22 @@ export function logEvent(message) {
     }
 }
 
+export function showEventPopup(event) {
+    const popup = document.getElementById('event-popup');
+    const nameEl = document.getElementById('event-name');
+    const descEl = document.getElementById('event-description');
+    nameEl.textContent = event.name;
+    descEl.textContent = event.description;
+    popup.style.display = 'block';
+    const config = getConfig();
+    const duration = event.duration ? event.duration * config.constants.DAY_LENGTH : 0;
+    const displaySeconds = Math.max(duration, 3);
+    if (popup._timeout) clearTimeout(popup._timeout);
+    popup._timeout = setTimeout(() => {
+        popup.style.display = 'none';
+    }, displaySeconds * 1000);
+}
+
 export function showUnlockPuzzle(puzzle) {
     const puzzlePopup = document.getElementById('puzzle-popup');
     document.getElementById('puzzle-title').textContent = 'Unlock New Feature';


### PR DESCRIPTION
## Summary
- convert event durations from days to seconds so effects last longer
- expand events in config with disasters, traders and weather
- display event popup on trigger that stays visible for the event duration (minimum 3s)

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b94d90c8320a3019bf7b4931442