### PR TITLE
Implement achievement tracking

### DIFF
--- a/achievements.js
+++ b/achievements.js
@@ -1,0 +1,50 @@
+import { gameState } from './gameState.js';
+import { logEvent } from './ui.js';
+
+export const achievementsList = [
+    { id: 'gather_10', name: 'First Forager', type: 'gatherCount', target: 10, reward: '🏅', description: 'Gather resources 10 times.' },
+    { id: 'craft_5', name: 'Apprentice Crafter', type: 'craftCount', target: 5, reward: '🔨', description: 'Craft 5 items.' },
+    { id: 'study_5', name: 'Scholar', type: 'studyCount', target: 5, reward: '📖', description: 'Study 5 times.' },
+    { id: 'pop_5', name: 'Growing Settlement', type: 'population', target: 5, reward: '👥', description: 'Reach population of 5.' }
+];
+
+export function initAchievements() {
+    updateAchievementList();
+}
+
+export function checkAchievements() {
+    let unlocked = false;
+    achievementsList.forEach(a => {
+        if (gameState.achievements[a.id]) return;
+        const progress = a.type === 'population' ? gameState.population : gameState[a.type] || 0;
+        if (progress >= a.target) {
+            gameState.achievements[a.id] = true;
+            logEvent(`Achievement unlocked: ${a.name}!`);
+            showAchievementPopup(a);
+            unlocked = true;
+        }
+    });
+    if (unlocked) updateAchievementList();
+}
+
+export function updateAchievementList() {
+    const list = document.getElementById('achievement-list');
+    if (!list) return;
+    list.innerHTML = '';
+    achievementsList.forEach(a => {
+        const li = document.createElement('li');
+        li.className = gameState.achievements[a.id] ? 'achievement-unlocked' : '';
+        const progress = a.type === 'population' ? gameState.population : gameState[a.type] || 0;
+        li.innerHTML = `<span class="achievement-name">${a.reward} ${a.name}</span> <span class="achievement-progress">${Math.min(progress, a.target)}/${a.target}</span>`;
+        list.appendChild(li);
+    });
+}
+
+function showAchievementPopup(a) {
+    const popup = document.getElementById('achievement-popup');
+    if (!popup) return;
+    popup.textContent = `${a.reward} Achievement unlocked: ${a.name}!`;
+    popup.style.display = 'block';
+    if (popup._timeout) clearTimeout(popup._timeout);
+    popup._timeout = setTimeout(() => { popup.style.display = 'none'; }, 3000);
+}

--- a/crafting.js
+++ b/crafting.js
@@ -1,5 +1,6 @@
 import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
 import { logEvent, updateDisplay, updateWorkingSection } from './ui.js';
+import { checkAchievements } from './achievements.js';
 import { updateAutomationControls } from './automation.js';
 
 const craftingQueue = [];
@@ -88,6 +89,7 @@ function completeCrafting(item) {
     updateWorkingSection();
     updateAutomationControls();
     gameState.craftCount += 1;
+    checkAchievements();
 
     if (gameState.craftingQueue.length > 0) {
         processQueue();

--- a/game.js
+++ b/game.js
@@ -5,6 +5,7 @@ import { updateCraftableItems, processQueue } from './crafting.js';
 import { updateAutomationControls, runAutomation } from './automation.js';
 import { checkForEvents, updateActiveEvents, advanceEventTime } from './events.js';
 import { initBook } from './book.js';
+import { initAchievements } from './achievements.js';
 
 function saveGame(manual = false) {
     gameState.lastSaved = Date.now();
@@ -92,6 +93,7 @@ async function initializeGame() {
     createGatheringActions(config.resources);
     updateGatherButtons();
     initBook();
+    initAchievements();
     updateDisplay();
     checkForEvents();
 

--- a/gameState.js
+++ b/gameState.js
@@ -15,7 +15,8 @@ export const gameState = {
     daysSinceGrowth: 0,
     dailyFoodConsumed: 0,
     dailyWaterConsumed: 0,
-    lastSaved: null
+    lastSaved: null,
+    achievements: {}
 };
 
 export async function loadGameConfig() {
@@ -28,6 +29,7 @@ export async function loadGameConfig() {
         
         // Initialize gameState with values from config
         Object.assign(gameState, gameConfig.initialState);
+        if (!gameState.achievements) gameState.achievements = {};
         gameState.availableWorkers = gameState.workers;
         gameState.automationProgress = {};
         gameState.dailyFoodConsumed = 0;

--- a/index.html
+++ b/index.html
@@ -106,6 +106,10 @@
             <h2>Automation</h2>
             <div id="automation-controls"></div>
         </div>
+        <div id="achievements" class="game-section">
+            <h2>Achievements</h2>
+            <ul id="achievement-list"></ul>
+        </div>
         <div id="log" class="game-section">
             <h2>Event Log</h2>
             <ul id="event-log"></ul>
@@ -117,6 +121,7 @@
         <button class="nav-btn" data-target="crafting"><i class="fas fa-hammer"></i><span>Craft</span></button>
         <button class="nav-btn" data-target="automation"><i class="fas fa-robot"></i><span>Auto</span></button>
         <button class="nav-btn" data-target="book"><i class="fas fa-book-open"></i><span>Book</span></button>
+        <button class="nav-btn" data-target="achievements"><i class="fas fa-trophy"></i><span>Achieve</span></button>
         <button class="nav-btn" data-target="log"><i class="fas fa-list"></i><span>Log</span></button>
         <button class="nav-btn" id="settings-btn"><i class="fas fa-ellipsis-v"></i><span>Info</span></button>
     </nav>
@@ -133,6 +138,8 @@
         <h2 id="event-name"></h2>
         <p id="event-description"></p>
     </div>
+
+    <div id="achievement-popup" class="popup"></div>
 
     <div id="settings-menu" class="popup">
         <h2>Settings</h2>

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -30,7 +30,8 @@
     "craftCount": 0,
     "daysSinceGrowth": 0,
     "automationProgress": {},
-    "lastSaved": 0
+    "lastSaved": 0,
+    "achievements": {}
   },
   "constants": {
     "DAY_LENGTH": 600,

--- a/resources.js
+++ b/resources.js
@@ -1,5 +1,6 @@
 import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
 import { logEvent, updateDisplay, updateWorkingSection, showUnlockPuzzle } from './ui.js';
+import { checkAchievements } from './achievements.js';
 import { updateAutomationControls } from './automation.js';
 import { updateCraftableItems, areDependenciesMet } from './crafting.js';
 
@@ -84,6 +85,7 @@ function completeGathering(resource) {
     updateCraftableItems();
     updateWorkingSection();
     gameState.gatherCount += 1;
+    checkAchievements();
 }
 
 
@@ -148,6 +150,7 @@ export function checkPopulationGrowth() {
         gameState.daysSinceGrowth = 0;
         updateAutomationControls();
         updateDisplay();
+        checkAchievements();
     }
 }
 
@@ -238,6 +241,7 @@ export function study() {
             }
             updateWorkingSection();
             gameState.studyCount += 1;
+            checkAchievements();
         }
     }, interval); // Study time affected by research speed
 }

--- a/styles.css
+++ b/styles.css
@@ -153,6 +153,26 @@ progress {
     text-align: center;
 }
 
+#achievement-list {
+    list-style: none;
+    padding: 0;
+}
+
+#achievement-list li {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+}
+
+.achievement-unlocked {
+    color: gold;
+}
+
+#achievement-popup {
+    min-width: 200px;
+    text-align: center;
+}
+
 .gather-action {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- introduce achievements with unlock popup
- track counts in game state
- display progress and add new navigation
- hook into gathering, crafting, studying and population growth

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c40d796fc8320a055df3344501aca