### PR TITLE
Add prestige system

### DIFF
--- a/automation.js
+++ b/automation.js
@@ -1,4 +1,4 @@
-import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
+import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
 import { updateDisplay, logEvent } from './ui.js';
 
 export function updateAutomationControls() {
@@ -79,21 +79,22 @@ export function runAutomation() {
         if (gameState.automationProgress[itemId] >= 10) {
             gameState.automationProgress[itemId] -= 10;
 
+            const mult = getPrestigeMultiplier();
             if (itemId.startsWith('gather_')) {
                 const resource = itemId.replace('gather_', '');
-                gameState[resource] = (gameState[resource] || 0) + count;
-                logEvent(`Workers gathered ${count} ${resource}.`);
+                gameState[resource] = (gameState[resource] || 0) + count * mult;
+                logEvent(`Workers gathered ${count * mult} ${resource}.`);
             } else {
                 const item = config.items.find(i => i.id === itemId);
                 if (item && item.effect) {
                     Object.entries(item.effect).forEach(([key]) => {
                         if (key.endsWith('ProductionRate')) {
                             const resource = key.replace('ProductionRate', '');
-                            gameState[resource] = (gameState[resource] || 0) + count;
+                            gameState[resource] = (gameState[resource] || 0) + count * mult;
                             if (resource === 'food' || resource === 'water') {
                                 gameState[resource] = Math.min(100, gameState[resource]);
                             }
-                            logEvent(`${item.name} produced ${count} ${resource}.`);
+                            logEvent(`${item.name} produced ${count * mult} ${resource}.`);
                         }
                     });
                 }

--- a/gameState.js
+++ b/gameState.js
@@ -16,6 +16,7 @@ export const gameState = {
     dailyFoodConsumed: 0,
     dailyWaterConsumed: 0,
     lastSaved: null,
+    prestigePoints: 0,
     achievements: {}
 };
 
@@ -51,4 +52,14 @@ export function adjustAvailableWorkers(delta) {
         0,
         Math.min(gameState.availableWorkers + delta, gameState.workers)
     );
+}
+
+export function getPrestigeMultiplier() {
+    let mult = 1 + (gameState.prestigePoints || 0) * 0.1;
+    Object.values(gameState.craftedItems).forEach(item => {
+        if (item.effect && item.effect.globalPrestigeMultiplier) {
+            mult *= item.effect.globalPrestigeMultiplier;
+        }
+    });
+    return mult;
 }

--- a/index.html
+++ b/index.html
@@ -145,6 +145,8 @@
         <h2>Settings</h2>
         <p id="game-title">Advanced Survival and Civilization Rebuilder</p>
         <button id="save-game-btn">Save Game</button>
+        <p>Prestige Points: <span id="prestige-points">0</span></p>
+        <button id="prestige-btn">Prestige</button>
         <button id="close-settings">Close</button>
     </div>
 

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -31,6 +31,7 @@
     "daysSinceGrowth": 0,
     "automationProgress": {},
     "lastSaved": 0,
+    "prestigePoints": 0,
     "achievements": {}
   },
   "constants": {

--- a/prestige.js
+++ b/prestige.js
@@ -1,0 +1,49 @@
+import { gameState } from './gameState.js';
+import { updateDisplay } from './ui.js';
+import { updateCraftableItems } from './crafting.js';
+import { updateAutomationControls } from './automation.js';
+
+export function calculatePrestigeGain() {
+    return Math.floor((gameState.knowledge || 0) / 100);
+}
+
+export function resetState() {
+    Object.assign(gameState, {
+        food: 100,
+        water: 100,
+        wood: 0,
+        stone: 0,
+        clay: 0,
+        fiber: 0,
+        ore: 0,
+        herbs: 0,
+        fruit: 0,
+        knowledge: 0,
+        population: 1,
+        workers: 0,
+        day: 1,
+        time: 0,
+        craftedItems: {},
+        automationAssignments: {},
+        availableWorkers: 0,
+        gatherCount: 0,
+        studyCount: 0,
+        craftCount: 0,
+        daysSinceGrowth: 0,
+        dailyFoodConsumed: 0,
+        dailyWaterConsumed: 0
+    });
+}
+
+export function prestigeGame() {
+    const gain = calculatePrestigeGain();
+    if (gain <= 0) {
+        alert('You need at least 100 knowledge to prestige.');
+        return;
+    }
+    gameState.prestigePoints = (gameState.prestigePoints || 0) + gain;
+    resetState();
+    updateCraftableItems();
+    updateAutomationControls();
+    updateDisplay();
+}

--- a/resources.js
+++ b/resources.js
@@ -1,4 +1,4 @@
-import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
+import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
 import { logEvent, updateDisplay, updateWorkingSection, showUnlockPuzzle } from './ui.js';
 import { checkAchievements } from './achievements.js';
 import { updateAutomationControls } from './automation.js';
@@ -71,6 +71,7 @@ function completeGathering(resource) {
 
     // Apply gathering efficiency modifier
     amount *= (gameState.gatheringEfficiency || 1);
+    amount *= getPrestigeMultiplier();
     
     // Round the amount to avoid fractional resources
     amount = Math.round(amount);
@@ -113,13 +114,14 @@ export function logDailyConsumption() {
 
 
 export function produceResources() {
+    const mult = getPrestigeMultiplier();
     if (gameState.craftedItems.farm) {
-        const foodProduced = gameState.craftedItems.farm.effect.foodProductionRate * (gameState.automationAssignments.farm || 0);
+        const foodProduced = gameState.craftedItems.farm.effect.foodProductionRate * (gameState.automationAssignments.farm || 0) * mult;
         gameState.food += foodProduced;
         logEvent(`Farm produced ${foodProduced.toFixed(1)} food.`);
     }
     if (gameState.craftedItems.well) {
-        const waterProduced = gameState.craftedItems.well.effect.waterProductionRate * (gameState.automationAssignments.well || 0);
+        const waterProduced = gameState.craftedItems.well.effect.waterProductionRate * (gameState.automationAssignments.well || 0) * mult;
         gameState.water += waterProduced;
         logEvent(`Well produced ${waterProduced.toFixed(1)} water.`);
     }

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-import { gameState, getConfig } from './gameState.js';
+import { gameState, getConfig, getPrestigeMultiplier } from './gameState.js';
 import { updateCraftableItems } from './crafting.js';
 import { getGatheringMultiplier } from './resources.js';
 
@@ -19,6 +19,8 @@ export function updateDisplay() {
     document.getElementById('available-workers').textContent = gameState.availableWorkers;
     document.getElementById('total-workers').textContent = gameState.workers;
     document.getElementById('day-count').textContent = gameState.day;
+    const prestigeEl = document.getElementById('prestige-points');
+    if (prestigeEl) prestigeEl.textContent = gameState.prestigePoints || 0;
     updateGatherButtons();
 }
 
@@ -131,7 +133,7 @@ export function updateGatherButtons() {
             multiplierSpan.className = 'multiplier';
             button.appendChild(multiplierSpan);
         }
-        const mult = getGatheringMultiplier(resource);
+        const mult = getGatheringMultiplier(resource) * getPrestigeMultiplier();
         multiplierSpan.textContent = mult > 1 ? `x${mult}` : '';
     });
 }


### PR DESCRIPTION
## Summary
- add prestige reset system with permanent bonuses
- multiply gathering and production by prestige points
- display prestige points and button in Settings menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c470937ec8320a9f59bc48b0db8c8