### PR TITLE
Add scavenge mini-game

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { gameState, loadGameConfig, getConfig, getPrestigeMultiplier } from './gameState.js';
 import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu, updateGatherButtons } from './ui.js';
-import { gatherResource, consumeResources, logDailyConsumption, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
+import { gatherResource, scavenge, consumeResources, logDailyConsumption, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
 import { updateCraftableItems, processQueue } from './crafting.js';
 import { updateAutomationControls, runAutomation } from './automation.js';
 import { prestigeGame, resetState } from './prestige.js';
@@ -164,6 +164,20 @@ function createGatheringActions(resources) {
         gatherAction.appendChild(button);
         actionsContainer.appendChild(gatherAction);
     });
+
+    // Scavenge mini-game button
+    const scavengeAction = document.createElement('div');
+    scavengeAction.className = 'gather-action';
+    const scavengeBtn = document.createElement('button');
+    scavengeBtn.id = 'scavenge';
+    scavengeBtn.className = 'progress-button';
+    scavengeBtn.innerHTML = '<span>Scavenge Ruins</span>';
+    const scavengeBar = document.createElement('div');
+    scavengeBar.className = 'progress-bar';
+    scavengeBtn.appendChild(scavengeBar);
+    scavengeBtn.addEventListener('click', scavenge);
+    scavengeAction.appendChild(scavengeBtn);
+    actionsContainer.appendChild(scavengeAction);
 }
 
 function gameLoop() {

--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -61,6 +61,7 @@ Each craftable item requires solving a puzzle, adding an element of problem-solv
 ## 8. Progression
 
 1. Early Game: Focus on survival, manually gathering resources
+   - New "Scavenge Ruins" mini-game offers random basic resources in short sessions
 2. Mid Game: Craft basic tools, build shelter, start automating resource gathering
 3. Late Game: Expand population, build advanced structures, focus on knowledge and tech advancement
 

--- a/resources.js
+++ b/resources.js
@@ -66,6 +66,51 @@ export function getGatheringRate(resource) {
     return getGatheringMultiplier(resource) / (getGatheringTime(resource) / 1000);
 }
 
+export function scavenge() {
+    if (gameState.availableWorkers === 0) {
+        logEvent("No available workers to scavenge.");
+        return;
+    }
+
+    const button = document.getElementById('scavenge');
+    const progressBar = button.querySelector('.progress-bar');
+    if (button.disabled) return;
+
+    button.disabled = true;
+    adjustAvailableWorkers(-1);
+    gameState.currentWork = { type: 'scavenging' };
+    updateWorkingSection();
+
+    let progress = 0;
+    const interval = 100;
+    const duration = 4000;
+    const progressInterval = setInterval(() => {
+        progress += interval;
+        progressBar.style.width = `${(progress / duration) * 100}%`;
+        if (progress >= duration) {
+            clearInterval(progressInterval);
+            completeScavenge();
+            button.disabled = false;
+            progressBar.style.width = '0%';
+        }
+    }, interval);
+}
+
+function completeScavenge() {
+    const rewards = ['wood', 'stone', 'food', 'water'];
+    const resource = rewards[Math.floor(Math.random() * rewards.length)];
+    const amount = Math.round((Math.random() * 2 + 1) * getPrestigeMultiplier());
+    gameState[resource] = (gameState[resource] || 0) + amount;
+    logEvent(`Scavenged ${amount} ${resource}.`);
+    adjustAvailableWorkers(1);
+    gameState.currentWork = null;
+    updateDisplay();
+    updateCraftableItems();
+    updateWorkingSection();
+    gameState.gatherCount += 1;
+    checkAchievements();
+}
+
 function completeGathering(resource) {
     let amount = getGatheringMultiplier(resource);
 


### PR DESCRIPTION
## Summary
- add a `Scavenge Ruins` mini-game for early resource gathering
- integrate new mini-game button in gathering actions
- document new option in game design doc

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(server started then stopped with CTRL-C)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ce17cf88320ac35812235b22fac