### PR TITLE
Add tutorial overlay

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,6 +7,7 @@ import { prestigeGame, resetState } from './prestige.js';
 import { checkForEvents, updateActiveEvents, advanceEventTime } from './events.js';
 import { initBook } from './book.js';
 import { initAchievements } from './achievements.js';
+import { startTutorial, checkTutorialProgress, nextStep, skipTutorial } from './tutorial.js';
 
 function saveGame(manual = false) {
     gameState.lastSaved = Date.now();
@@ -131,6 +132,14 @@ async function initializeGame() {
         });
     });
 
+    // Tutorial buttons
+    const nextBtn = document.getElementById('tutorial-next');
+    const skipBtn = document.getElementById('tutorial-skip');
+    if (nextBtn) nextBtn.addEventListener('click', nextStep);
+    if (skipBtn) skipBtn.addEventListener('click', skipTutorial);
+
+    startTutorial();
+
     // Start game loop
     setInterval(gameLoop, 1000); // Update every second
     setInterval(saveGame, 30000); // Auto-save every 30 seconds
@@ -192,6 +201,7 @@ function gameLoop() {
     runAutomation();
     updateActiveEvents();
     checkSurvival();
+    checkTutorialProgress();
     updateDisplay();
     processQueue();
 }

--- a/index.html
+++ b/index.html
@@ -142,6 +142,12 @@
 
     <div id="achievement-popup" class="popup"></div>
 
+    <div id="tutorial-overlay" class="popup">
+        <p id="tutorial-text"></p>
+        <button id="tutorial-next">Next</button>
+        <button id="tutorial-skip">Skip</button>
+    </div>
+
     <div id="settings-menu" class="popup">
         <h2>Settings</h2>
         <p id="game-title">Advanced Survival and Civilization Rebuilder</p>

--- a/styles.css
+++ b/styles.css
@@ -138,6 +138,10 @@ progress {
     z-index: 1000;
 }
 
+.highlight {
+    box-shadow: 0 0 10px 2px yellow;
+}
+
 .popup input {
     width: 100%;
     padding: 5px;

--- a/tutorial.js
+++ b/tutorial.js
@@ -1,0 +1,77 @@
+import { gameState } from './gameState.js';
+
+let currentStep = 0;
+
+const steps = [
+    { text: 'Welcome to the wasteland! This short tutorial will guide you through the basics.' },
+    {
+        text: 'First, gather some wood by pressing the "Gather Wood" button.',
+        check: () => gameState.wood > 0,
+        highlight: '#gather-wood'
+    },
+    {
+        text: 'Great! Now open the Book tab to study knowledge.',
+        check: () => document.getElementById('book').classList.contains('game-section-active'),
+        highlight: '#bottom-nav button[data-target="book"]'
+    },
+    {
+        text: 'Next, open the Crafting tab to craft useful items.',
+        check: () => document.getElementById('crafting').classList.contains('game-section-active'),
+        highlight: '#bottom-nav button[data-target="crafting"]'
+    },
+    { text: 'You\'re all set! Survive and rebuild civilization.', end: true }
+];
+
+export function startTutorial() {
+    const saved = Number(localStorage.getItem('tutorialStep') || '0');
+    currentStep = saved;
+    if (currentStep >= steps.length) return;
+    showStep();
+}
+
+export function nextStep() {
+    removeHighlights();
+    currentStep += 1;
+    localStorage.setItem('tutorialStep', currentStep);
+    if (currentStep >= steps.length) {
+        endTutorial();
+    } else {
+        showStep();
+    }
+}
+
+export function checkTutorialProgress() {
+    const step = steps[currentStep];
+    if (step && step.check && step.check()) {
+        nextStep();
+    }
+}
+
+function showStep() {
+    const overlay = document.getElementById('tutorial-overlay');
+    const textEl = document.getElementById('tutorial-text');
+    const step = steps[currentStep];
+    if (!step) return;
+    overlay.style.display = 'block';
+    textEl.textContent = step.text;
+    if (step.highlight) {
+        const el = document.querySelector(step.highlight);
+        if (el) el.classList.add('highlight');
+    }
+}
+
+function removeHighlights() {
+    document.querySelectorAll('.highlight').forEach(el => el.classList.remove('highlight'));
+}
+
+function endTutorial() {
+    const overlay = document.getElementById('tutorial-overlay');
+    overlay.style.display = 'none';
+    removeHighlights();
+}
+
+export function skipTutorial() {
+    currentStep = steps.length;
+    localStorage.setItem('tutorialStep', currentStep);
+    endTutorial();
+}


### PR DESCRIPTION
## Summary
- add `tutorial.js` for basic step-by-step guide
- insert tutorial overlay markup
- highlight buttons when tutorial steps are active
- integrate tutorial into game loop

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c4de85c148320bcfc3e1df887ef4c