### PR TITLE
Add lifetime statistics screen

### DIFF
--- a/automation.js
+++ b/automation.js
@@ -1,5 +1,6 @@
 import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
 import { updateDisplay, logEvent } from './ui.js';
+import { recordResourceGain } from './stats.js';
 
 export function updateAutomationControls() {
     const config = getConfig();
@@ -83,6 +84,7 @@ export function runAutomation() {
             if (itemId.startsWith('gather_')) {
                 const resource = itemId.replace('gather_', '');
                 gameState[resource] = (gameState[resource] || 0) + count * mult;
+                recordResourceGain(resource, count * mult);
                 logEvent(`Workers gathered ${count * mult} ${resource}.`);
             } else {
                 const item = config.items.find(i => i.id === itemId);
@@ -91,6 +93,7 @@ export function runAutomation() {
                         if (key.endsWith('ProductionRate')) {
                             const resource = key.replace('ProductionRate', '');
                             gameState[resource] = (gameState[resource] || 0) + count * mult;
+                            recordResourceGain(resource, count * mult);
                             if (resource === 'food' || resource === 'water') {
                                 gameState[resource] = Math.min(100, gameState[resource]);
                             }

--- a/crafting.js
+++ b/crafting.js
@@ -2,6 +2,7 @@ import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
 import { logEvent, updateDisplay, updateWorkingSection } from './ui.js';
 import { checkAchievements } from './achievements.js';
 import { updateAutomationControls } from './automation.js';
+import { recordItemCraft } from './stats.js';
 
 const craftingQueue = [];
 
@@ -78,6 +79,7 @@ export function processQueue() {
 function completeCrafting(item) {
     // Store the full item data so other systems can access its effects
     gameState.craftedItems[item.id] = item;
+    recordItemCraft(item.id);
     logEvent(`Crafted ${item.name}!`);
     
     adjustAvailableWorkers(1);

--- a/events.js
+++ b/events.js
@@ -1,5 +1,6 @@
 import { gameState, getConfig } from './gameState.js';
 import { logEvent, updateDisplay, showEventPopup } from './ui.js';
+import { recordResourceGain } from './stats.js';
 
 let activeEvents = [];
 
@@ -19,6 +20,7 @@ function triggerEvent(event) {
     Object.entries(event.effect).forEach(([key, value]) => {
         if (key in gameState) {
             gameState[key] += value;
+            if (value > 0) recordResourceGain(key, value);
         } else if (key === 'gatheringEfficiency') {
             // Store the efficiency modifier
             gameState.gatheringEfficiency = (gameState.gatheringEfficiency || 1) * value;

--- a/game.js
+++ b/game.js
@@ -8,6 +8,7 @@ import { checkForEvents, updateActiveEvents, advanceEventTime } from './events.j
 import { initBook } from './book.js';
 import { initAchievements } from './achievements.js';
 import { startTutorial, checkTutorialProgress, nextStep, skipTutorial } from './tutorial.js';
+import { recordResourceGain } from './stats.js';
 
 function saveGame(manual = false) {
     gameState.lastSaved = Date.now();
@@ -45,14 +46,18 @@ function applyOfflineProgress() {
         if (count <= 0) return;
         if (itemId.startsWith('gather_')) {
             const resource = itemId.replace('gather_', '');
-            gameState[resource] = (gameState[resource] || 0) + count * cycles * mult;
+            const gained = count * cycles * mult;
+            gameState[resource] = (gameState[resource] || 0) + gained;
+            recordResourceGain(resource, gained);
         } else {
             const item = config.items.find(i => i.id === itemId);
             if (item && item.effect) {
                 Object.keys(item.effect).forEach(key => {
                     if (key.endsWith('ProductionRate')) {
                         const resource = key.replace('ProductionRate', '');
-                        gameState[resource] = (gameState[resource] || 0) + count * cycles * mult;
+                        const gained = count * cycles * mult;
+                        gameState[resource] = (gameState[resource] || 0) + gained;
+                        recordResourceGain(resource, gained);
                         if (resource === 'food' || resource === 'water') {
                             gameState[resource] = Math.min(100, gameState[resource]);
                         }

--- a/gameState.js
+++ b/gameState.js
@@ -17,7 +17,11 @@ export const gameState = {
     dailyWaterConsumed: 0,
     lastSaved: null,
     prestigePoints: 0,
-    achievements: {}
+    achievements: {},
+    stats: {
+        resourcesGathered: {},
+        itemsCrafted: {}
+    }
 };
 
 export async function loadGameConfig() {
@@ -31,6 +35,9 @@ export async function loadGameConfig() {
         // Initialize gameState with values from config
         Object.assign(gameState, gameConfig.initialState);
         if (!gameState.achievements) gameState.achievements = {};
+        if (!gameState.stats) {
+            gameState.stats = { resourcesGathered: {}, itemsCrafted: {} };
+        }
         gameState.availableWorkers = gameState.workers;
         gameState.automationProgress = {};
         gameState.dailyFoodConsumed = 0;

--- a/index.html
+++ b/index.html
@@ -107,6 +107,10 @@
             <h2>Automation</h2>
             <div id="automation-controls"></div>
         </div>
+        <div id="stats" class="game-section">
+            <h2>Statistics</h2>
+            <div id="stats-content"></div>
+        </div>
         <div id="achievements" class="game-section">
             <h2>Achievements</h2>
             <ul id="achievement-list"></ul>
@@ -122,6 +126,7 @@
         <button class="nav-btn" data-target="crafting"><i class="fas fa-hammer"></i><span>Craft</span></button>
         <button class="nav-btn" data-target="automation"><i class="fas fa-robot"></i><span>Auto</span></button>
         <button class="nav-btn" data-target="book"><i class="fas fa-book-open"></i><span>Book</span></button>
+        <button class="nav-btn" data-target="stats"><i class="fas fa-chart-bar"></i><span>Stats</span></button>
         <button class="nav-btn" data-target="achievements"><i class="fas fa-trophy"></i><span>Achieve</span></button>
         <button class="nav-btn" data-target="log"><i class="fas fa-list"></i><span>Log</span></button>
         <button class="nav-btn" id="settings-btn"><i class="fas fa-ellipsis-v"></i><span>Info</span></button>

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -32,7 +32,11 @@
     "automationProgress": {},
     "lastSaved": 0,
     "prestigePoints": 0,
-    "achievements": {}
+    "achievements": {},
+    "stats": {
+      "resourcesGathered": {},
+      "itemsCrafted": {}
+    }
   },
   "constants": {
     "DAY_LENGTH": 600,

--- a/resources.js
+++ b/resources.js
@@ -1,6 +1,7 @@
 import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
 import { logEvent, updateDisplay, updateWorkingSection, showUnlockPuzzle } from './ui.js';
 import { checkAchievements } from './achievements.js';
+import { recordResourceGain } from './stats.js';
 import { updateAutomationControls } from './automation.js';
 import { updateCraftableItems, areDependenciesMet } from './crafting.js';
 
@@ -101,6 +102,7 @@ function completeScavenge() {
     const resource = rewards[Math.floor(Math.random() * rewards.length)];
     const amount = Math.round((Math.random() * 2 + 1) * getPrestigeMultiplier());
     gameState[resource] = (gameState[resource] || 0) + amount;
+    recordResourceGain(resource, amount);
     logEvent(`Scavenged ${amount} ${resource}.`);
     adjustAvailableWorkers(1);
     gameState.currentWork = null;
@@ -122,6 +124,7 @@ function completeGathering(resource) {
     amount = Math.round(amount);
 
     gameState[resource] += amount;
+    recordResourceGain(resource, amount);
     logEvent(`Gathered ${amount} ${resource}.`);
 
     adjustAvailableWorkers(1);
@@ -163,11 +166,13 @@ export function produceResources() {
     if (gameState.craftedItems.farm) {
         const foodProduced = gameState.craftedItems.farm.effect.foodProductionRate * (gameState.automationAssignments.farm || 0) * mult;
         gameState.food += foodProduced;
+        recordResourceGain('food', foodProduced);
         logEvent(`Farm produced ${foodProduced.toFixed(1)} food.`);
     }
     if (gameState.craftedItems.well) {
         const waterProduced = gameState.craftedItems.well.effect.waterProductionRate * (gameState.automationAssignments.well || 0) * mult;
         gameState.water += waterProduced;
+        recordResourceGain('water', waterProduced);
         logEvent(`Well produced ${waterProduced.toFixed(1)} water.`);
     }
     gameState.food = Math.min(gameState.food, 100);

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,22 @@
+import { gameState } from './gameState.js';
+
+export function ensureStats() {
+    if (!gameState.stats) {
+        gameState.stats = { resourcesGathered: {}, itemsCrafted: {} };
+    }
+    if (!gameState.stats.resourcesGathered) gameState.stats.resourcesGathered = {};
+    if (!gameState.stats.itemsCrafted) gameState.stats.itemsCrafted = {};
+}
+
+export function recordResourceGain(resource, amount) {
+    if (amount <= 0) return;
+    ensureStats();
+    gameState.stats.resourcesGathered[resource] =
+        (gameState.stats.resourcesGathered[resource] || 0) + amount;
+}
+
+export function recordItemCraft(itemId) {
+    ensureStats();
+    gameState.stats.itemsCrafted[itemId] =
+        (gameState.stats.itemsCrafted[itemId] || 0) + 1;
+}

--- a/ui.js
+++ b/ui.js
@@ -23,6 +23,7 @@ export function updateDisplay() {
     if (prestigeEl) prestigeEl.textContent = gameState.prestigePoints || 0;
     updateGatherButtons();
     updateGrowthIndicators();
+    updateStatsDisplay();
 }
 
 // Previously displayed current work progress. Section removed, so keep stub.
@@ -171,4 +172,40 @@ export function updateGrowthIndicators() {
         li.textContent = `${req.met ? '✅' : '❌'} ${req.text}`;
         list.appendChild(li);
     });
+}
+
+export function updateStatsDisplay() {
+    const container = document.getElementById('stats-content');
+    if (!container) return;
+    const stats = gameState.stats || { resourcesGathered: {}, itemsCrafted: {} };
+    container.innerHTML = '';
+
+    const dayP = document.createElement('p');
+    dayP.textContent = `Days Survived: ${gameState.day}`;
+    container.appendChild(dayP);
+
+    const resHeader = document.createElement('h3');
+    resHeader.textContent = 'Resources Gathered';
+    container.appendChild(resHeader);
+    const resList = document.createElement('ul');
+    Object.entries(stats.resourcesGathered).forEach(([res, amt]) => {
+        const li = document.createElement('li');
+        li.textContent = `${res}: ${Math.floor(amt)}`;
+        resList.appendChild(li);
+    });
+    container.appendChild(resList);
+
+    const itemHeader = document.createElement('h3');
+    itemHeader.textContent = 'Items Crafted';
+    container.appendChild(itemHeader);
+    const itemList = document.createElement('ul');
+    const config = getConfig();
+    Object.entries(stats.itemsCrafted).forEach(([id, count]) => {
+        const item = config.items.find(i => i.id === id);
+        const name = item ? item.name : id;
+        const li = document.createElement('li');
+        li.textContent = `${name}: ${count}`;
+        itemList.appendChild(li);
+    });
+    container.appendChild(itemList);
 }


### PR DESCRIPTION
## Summary
- track lifetime resources gathered and items crafted
- display stats in a new Statistics section
- record gains from events, automation, offline progress, and crafting
- include stats in saved state defaults

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c51dcb9048320aea1278c0ebd9b4e