### PR TITLE
Add expedition gameplay feature

### DIFF
--- a/events.js
+++ b/events.js
@@ -64,3 +64,11 @@ function endEvent(event) {
 
     updateDisplay();
 }
+
+export function triggerRandomEvent() {
+    const config = getConfig();
+    const events = config.events;
+    if (events.length === 0) return;
+    const event = events[Math.floor(Math.random() * events.length)];
+    triggerEvent(event);
+}

--- a/expeditions.js
+++ b/expeditions.js
@@ -1,0 +1,66 @@
+import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
+import { logEvent } from './ui.js';
+import { recordResourceGain } from './stats.js';
+import { triggerRandomEvent } from './events.js';
+
+export function initExpeditions() {
+    const btn = document.getElementById('start-expedition');
+    if (btn) {
+        btn.addEventListener('click', startExpedition);
+    }
+    updateExpeditionUI();
+}
+
+export function startExpedition() {
+    if (gameState.availableWorkers <= 0) {
+        logEvent('No available workers for an expedition.');
+        return;
+    }
+    const config = getConfig();
+    const duration = config.constants.EXPEDITION_DURATION || 30;
+    gameState.expeditions.push({ remaining: duration });
+    adjustAvailableWorkers(-1);
+    logEvent('An expedition has set out.');
+    updateExpeditionUI();
+}
+
+function completeExpedition() {
+    adjustAvailableWorkers(1);
+    const config = getConfig();
+    if (Math.random() < 0.2) {
+        triggerRandomEvent();
+    } else {
+        const rewards = config.resources;
+        const resource = rewards[Math.floor(Math.random() * rewards.length)];
+        const amount = Math.round(Math.random() * 5 + 5);
+        gameState[resource] = (gameState[resource] || 0) + amount;
+        recordResourceGain(resource, amount);
+        logEvent(`Expedition returned with ${amount} ${resource}.`);
+    }
+}
+
+export function updateExpeditions() {
+    const completed = [];
+    gameState.expeditions.forEach(exp => {
+        exp.remaining -= 1;
+        if (exp.remaining <= 0) completed.push(exp);
+    });
+    completed.forEach(exp => {
+        completeExpedition();
+    });
+    if (completed.length > 0) {
+        gameState.expeditions = gameState.expeditions.filter(e => e.remaining > 0);
+        updateExpeditionUI();
+    }
+}
+
+function updateExpeditionUI() {
+    const list = document.getElementById('expedition-list');
+    if (!list) return;
+    list.innerHTML = '';
+    gameState.expeditions.forEach((exp, index) => {
+        const li = document.createElement('div');
+        li.textContent = `Expedition ${index + 1}: ${exp.remaining}s remaining`;
+        list.appendChild(li);
+    });
+}

--- a/game.js
+++ b/game.js
@@ -9,6 +9,7 @@ import { initBook } from './book.js';
 import { initAchievements } from './achievements.js';
 import { startTutorial, checkTutorialProgress, nextStep, skipTutorial } from './tutorial.js';
 import { recordResourceGain } from './stats.js';
+import { initExpeditions, updateExpeditions } from './expeditions.js';
 
 function saveGame(manual = false) {
     gameState.lastSaved = Date.now();
@@ -102,6 +103,7 @@ async function initializeGame() {
     updateGatherButtons();
     initBook();
     initAchievements();
+    initExpeditions();
     updateDisplay();
     checkForEvents();
 
@@ -205,6 +207,7 @@ function gameLoop() {
     }
     runAutomation();
     updateActiveEvents();
+    updateExpeditions();
     checkSurvival();
     checkTutorialProgress();
     updateDisplay();

--- a/gameState.js
+++ b/gameState.js
@@ -13,6 +13,7 @@ export const gameState = {
     studyCount: 0,
     craftCount: 0,
     daysSinceGrowth: 0,
+    expeditions: [],
     dailyFoodConsumed: 0,
     dailyWaterConsumed: 0,
     lastSaved: null,

--- a/index.html
+++ b/index.html
@@ -107,6 +107,11 @@
             <h2>Automation</h2>
             <div id="automation-controls"></div>
         </div>
+        <div id="expeditions" class="game-section">
+            <h2>Expeditions</h2>
+            <button id="start-expedition" class="progress-button">Start Expedition</button>
+            <div id="expedition-list"></div>
+        </div>
         <div id="stats" class="game-section">
             <h2>Statistics</h2>
             <div id="stats-content"></div>
@@ -125,6 +130,7 @@
         <button class="nav-btn active" data-target="actions"><i class="fas fa-hand-paper"></i><span>Gather</span></button>
         <button class="nav-btn" data-target="crafting"><i class="fas fa-hammer"></i><span>Craft</span></button>
         <button class="nav-btn" data-target="automation"><i class="fas fa-robot"></i><span>Auto</span></button>
+        <button class="nav-btn" data-target="expeditions"><i class="fas fa-compass"></i><span>Exped</span></button>
         <button class="nav-btn" data-target="book"><i class="fas fa-book-open"></i><span>Book</span></button>
         <button class="nav-btn" data-target="stats"><i class="fas fa-chart-bar"></i><span>Stats</span></button>
         <button class="nav-btn" data-target="achievements"><i class="fas fa-trophy"></i><span>Achieve</span></button>

--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -29,6 +29,7 @@
     "studyCount": 0,
     "craftCount": 0,
     "daysSinceGrowth": 0,
+    "expeditions": [],
     "automationProgress": {},
     "lastSaved": 0,
     "prestigePoints": 0,
@@ -47,7 +48,8 @@
     "POPULATION_STUDY_REQUIRED": 1,
     "POPULATION_CRAFT_REQUIRED": 1,
     "POPULATION_GROWTH_COST": 5,
-    "OFFLINE_PROGRESS_LIMIT": 28800
+    "OFFLINE_PROGRESS_LIMIT": 28800,
+    "EXPEDITION_DURATION": 30
   },
   "gatheringTimes": {
     "wood": 5000,


### PR DESCRIPTION
## Summary
- introduce expeditions.js to manage worker expeditions
- enable expeditions via new UI section and nav entry
- call expedition logic from game loop
- keep expedition settings in game state and config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c539e67688320a745e856509456ec