### PR TITLE
Improve game loop

### DIFF
--- a/automation.js
+++ b/automation.js
@@ -70,14 +70,14 @@ function updateAutomationDisplay() {
     });
 }
 
-export function runAutomation() {
+export function runAutomation(seconds = 1) {
     const config = getConfig();
     Object.entries(gameState.automationAssignments).forEach(([itemId, count]) => {
         if (count <= 0) return;
 
-        gameState.automationProgress[itemId] = (gameState.automationProgress[itemId] || 0) + 1;
+        gameState.automationProgress[itemId] = (gameState.automationProgress[itemId] || 0) + seconds;
 
-        if (gameState.automationProgress[itemId] >= 10) {
+        while (gameState.automationProgress[itemId] >= 10) {
             gameState.automationProgress[itemId] -= 10;
 
             const mult = getPrestigeMultiplier();
@@ -105,4 +105,8 @@ export function runAutomation() {
         }
     });
     updateDisplay();
+}
+
+export function hasActiveAutomation() {
+    return Object.values(gameState.automationAssignments).some(v => v > 0);
 }

--- a/events.js
+++ b/events.js
@@ -47,8 +47,12 @@ export function advanceEventTime(seconds) {
     });
 }
 
-export function updateActiveEvents() {
-    advanceEventTime(1);
+export function updateActiveEvents(seconds = 1) {
+    advanceEventTime(seconds);
+}
+
+export function hasActiveEvents() {
+    return activeEvents.length > 0;
 }
 
 function endEvent(event) {

--- a/expeditions.js
+++ b/expeditions.js
@@ -39,10 +39,10 @@ function completeExpedition() {
     }
 }
 
-export function updateExpeditions() {
+export function updateExpeditions(seconds = 1) {
     const completed = [];
     gameState.expeditions.forEach(exp => {
-        exp.remaining -= 1;
+        exp.remaining -= seconds;
         if (exp.remaining <= 0) completed.push(exp);
     });
     completed.forEach(exp => {
@@ -52,6 +52,10 @@ export function updateExpeditions() {
         gameState.expeditions = gameState.expeditions.filter(e => e.remaining > 0);
         updateExpeditionUI();
     }
+}
+
+export function hasExpeditions() {
+    return gameState.expeditions.length > 0;
 }
 
 function updateExpeditionUI() {


### PR DESCRIPTION
## Summary
- compute delta time so the game loop can update in variable increments
- scale automation, events, and expeditions updates by seconds
- schedule game loop using dynamic intervals based on activity

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c56392b64832099a8edddb5d1ed8b