### PR TITLE
Improve accelerated time display

### DIFF
--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -54,8 +54,8 @@ Each craftable item requires solving a puzzle, adding an element of problem-solv
 
 ## 7. Day/Night Cycle
 
-- A full day lasts 10 minutes in real-time
-- 5 minutes of daylight, 5 minutes of night
+- A full day lasts 10 minutes in real-time, representing a 24 hour cycle
+- Morning begins at **06:00**, afternoon at **12:00** and night at **20:00**
 - Certain activities may be more or less efficient depending on the time of day
 
 ## 8. Progression

--- a/ui.js
+++ b/ui.js
@@ -35,18 +35,23 @@ export function updateWorkingSection() {}
 
 export function updateTimeDisplay() {
     const config = getConfig();
-    const hours = Math.floor(gameState.time / 60);
-    const minutes = gameState.time % 60;
+    const dayLength = config.constants.DAY_LENGTH;
+    const totalMinutes = (gameState.time / dayLength) * 1440;
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = Math.floor(totalMinutes % 60);
     document.getElementById('time-display').textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
 export function updateTimeEmoji() {
     const config = getConfig();
+    const dayLength = config.constants.DAY_LENGTH;
+    const totalHours = (gameState.time / dayLength) * 24;
+    const hours = Math.floor(totalHours);
     const timeEmojiElement = document.getElementById('time-emoji');
-    if (gameState.time < config.constants.DAY_PHASE) {
-        timeEmojiElement.textContent = '☀️';
-    } else {
+    if (hours >= 20 || hours < 6) {
         timeEmojiElement.textContent = '🌙';
+    } else {
+        timeEmojiElement.textContent = '☀️';
     }
 }
 


### PR DESCRIPTION
## Summary
- display in-game time using a 24‑hour clock
- update emoji based on night cycle
- clarify day/night details in the design doc

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c657b0c2883208ce5cdecf3abef79