### PR TITLE
Add Android wrapper and tests

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.example.afk"
+        minSdkVersion 21
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.webkit:webkit:1.7.0'
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# ProGuard rules for AFK game

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.afk">
+
+    <application
+        android:label="AFK Game"
+        android:allowBackup="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/assets/www/achievements.js
+++ b/android/app/src/main/assets/www/achievements.js
@@ -1,0 +1,50 @@
+import { gameState } from './gameState.js';
+import { logEvent } from './ui.js';
+
+export const achievementsList = [
+    { id: 'gather_10', name: 'First Forager', type: 'gatherCount', target: 10, reward: '🏅', description: 'Gather resources 10 times.' },
+    { id: 'craft_5', name: 'Apprentice Crafter', type: 'craftCount', target: 5, reward: '🔨', description: 'Craft 5 items.' },
+    { id: 'study_5', name: 'Scholar', type: 'studyCount', target: 5, reward: '📖', description: 'Study 5 times.' },
+    { id: 'pop_5', name: 'Growing Settlement', type: 'population', target: 5, reward: '👥', description: 'Reach population of 5.' }
+];
+
+export function initAchievements() {
+    updateAchievementList();
+}
+
+export function checkAchievements() {
+    let unlocked = false;
+    achievementsList.forEach(a => {
+        if (gameState.achievements[a.id]) return;
+        const progress = a.type === 'population' ? gameState.population : gameState[a.type] || 0;
+        if (progress >= a.target) {
+            gameState.achievements[a.id] = true;
+            logEvent(`Achievement unlocked: ${a.name}!`);
+            showAchievementPopup(a);
+            unlocked = true;
+        }
+    });
+    if (unlocked) updateAchievementList();
+}
+
+export function updateAchievementList() {
+    const list = document.getElementById('achievement-list');
+    if (!list) return;
+    list.innerHTML = '';
+    achievementsList.forEach(a => {
+        const li = document.createElement('li');
+        li.className = gameState.achievements[a.id] ? 'achievement-unlocked' : '';
+        const progress = a.type === 'population' ? gameState.population : gameState[a.type] || 0;
+        li.innerHTML = `<span class="achievement-name">${a.reward} ${a.name}</span> <span class="achievement-progress">${Math.min(progress, a.target)}/${a.target}</span>`;
+        list.appendChild(li);
+    });
+}
+
+function showAchievementPopup(a) {
+    const popup = document.getElementById('achievement-popup');
+    if (!popup) return;
+    popup.textContent = `${a.reward} Achievement unlocked: ${a.name}!`;
+    popup.style.display = 'block';
+    if (popup._timeout) clearTimeout(popup._timeout);
+    popup._timeout = setTimeout(() => { popup.style.display = 'none'; }, 3000);
+}

--- a/android/app/src/main/assets/www/automation.js
+++ b/android/app/src/main/assets/www/automation.js
@@ -1,0 +1,112 @@
+import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
+import { updateDisplay, logEvent } from './ui.js';
+import { recordResourceGain } from './stats.js';
+
+export function updateAutomationControls() {
+    const config = getConfig();
+    const automationControlsContainer = document.getElementById('automation-controls');
+    automationControlsContainer.innerHTML = '';
+
+    config.items.forEach(item => {
+        if (gameState.craftedItems[item.id] && (item.effect.foodProductionRate || item.effect.waterProductionRate)) {
+            const div = document.createElement('div');
+            div.className = 'automation-control';
+            div.innerHTML = `
+                <p>${item.name}: <span id="${item.id}-assigned">0</span> assigned</p>
+                <button id="${item.id}-assign">+</button>
+                <button id="${item.id}-unassign">-</button>
+            `;
+            automationControlsContainer.appendChild(div);
+            document.getElementById(`${item.id}-assign`).addEventListener('click', () => assignWorker(item.id));
+            document.getElementById(`${item.id}-unassign`).addEventListener('click', () => unassignWorker(item.id));
+        }
+    });
+
+    // Auto-gather wood when axe is crafted
+    if (gameState.craftedItems.axe) {
+        addResourceControl('wood', 'Chop Wood');
+    }
+}
+
+function addResourceControl(resource, label) {
+    const container = document.getElementById('automation-controls');
+    const id = `gather_${resource}`;
+    const div = document.createElement('div');
+    div.className = 'automation-control';
+    div.innerHTML = `
+        <p>${label}: <span id="${id}-assigned">${gameState.automationAssignments[id] || 0}</span> assigned</p>
+        <button id="${id}-assign">+</button>
+        <button id="${id}-unassign">-</button>
+    `;
+    container.appendChild(div);
+    document.getElementById(`${id}-assign`).addEventListener('click', () => assignWorker(id));
+    document.getElementById(`${id}-unassign`).addEventListener('click', () => unassignWorker(id));
+}
+
+function assignWorker(itemId) {
+    if (gameState.availableWorkers > 0) {
+        gameState.automationAssignments[itemId] = (gameState.automationAssignments[itemId] || 0) + 1;
+        adjustAvailableWorkers(-1);
+        updateAutomationDisplay();
+        updateDisplay();
+    }
+}
+
+function unassignWorker(itemId) {
+    if (gameState.automationAssignments[itemId] > 0) {
+        gameState.automationAssignments[itemId] -= 1;
+        adjustAvailableWorkers(1);
+        updateAutomationDisplay();
+        updateDisplay();
+    }
+}
+
+function updateAutomationDisplay() {
+    Object.entries(gameState.automationAssignments).forEach(([itemId, count]) => {
+        const assignedElement = document.getElementById(`${itemId}-assigned`);
+        if (assignedElement) {
+            assignedElement.textContent = count;
+        }
+    });
+}
+
+export function runAutomation(seconds = 1) {
+    const config = getConfig();
+    Object.entries(gameState.automationAssignments).forEach(([itemId, count]) => {
+        if (count <= 0) return;
+
+        gameState.automationProgress[itemId] = (gameState.automationProgress[itemId] || 0) + seconds;
+
+        while (gameState.automationProgress[itemId] >= 10) {
+            gameState.automationProgress[itemId] -= 10;
+
+            const mult = getPrestigeMultiplier();
+            if (itemId.startsWith('gather_')) {
+                const resource = itemId.replace('gather_', '');
+                gameState[resource] = (gameState[resource] || 0) + count * mult;
+                recordResourceGain(resource, count * mult);
+                logEvent(`Workers gathered ${count * mult} ${resource}.`);
+            } else {
+                const item = config.items.find(i => i.id === itemId);
+                if (item && item.effect) {
+                    Object.entries(item.effect).forEach(([key]) => {
+                        if (key.endsWith('ProductionRate')) {
+                            const resource = key.replace('ProductionRate', '');
+                            gameState[resource] = (gameState[resource] || 0) + count * mult;
+                            recordResourceGain(resource, count * mult);
+                            if (resource === 'food' || resource === 'water') {
+                                gameState[resource] = Math.min(100, gameState[resource]);
+                            }
+                            logEvent(`${item.name} produced ${count * mult} ${resource}.`);
+                        }
+                    });
+                }
+            }
+        }
+    });
+    updateDisplay();
+}
+
+export function hasActiveAutomation() {
+    return Object.values(gameState.automationAssignments).some(v => v > 0);
+}

--- a/android/app/src/main/assets/www/book.js
+++ b/android/app/src/main/assets/www/book.js
@@ -1,0 +1,101 @@
+import { gameState, getConfig } from './gameState.js';
+import { updateDisplay } from './ui.js';
+import { updateCraftableItems } from './crafting.js';
+
+export function initBook() {
+    gameState.currentBookIndex = 0;
+    document.getElementById('book-submit').addEventListener('click', submitAnswer);
+    document.getElementById('book-next').addEventListener('click', nextPage);
+    document.getElementById('book-prev').addEventListener('click', prevPage);
+    renderPage();
+}
+
+function getPuzzles() {
+    const config = getConfig();
+    return config.unlockPuzzles;
+}
+
+function getCurrentPuzzle() {
+    const puzzles = getPuzzles();
+    return puzzles[gameState.currentBookIndex] || null;
+}
+
+export function renderPage() {
+    const puzzles = getPuzzles();
+    const puzzle = getCurrentPuzzle();
+    const questionDiv = document.getElementById('book-question');
+    const infoDiv = document.getElementById('book-item-info');
+    const prevBtn = document.getElementById('book-prev');
+    const nextBtn = document.getElementById('book-next');
+
+    prevBtn.disabled = gameState.currentBookIndex === 0;
+
+    if (!puzzle) {
+        questionDiv.style.display = 'none';
+        infoDiv.style.display = 'block';
+        infoDiv.innerHTML = '<p>All pages unlocked!</p>';
+        nextBtn.disabled = true;
+        return;
+    }
+    if (gameState.unlockedFeatures.includes(puzzle.unlocks)) {
+        questionDiv.style.display = 'none';
+        infoDiv.style.display = 'block';
+        const item = getConfig().items.find(i => i.id === puzzle.unlocks);
+        if (item) {
+            infoDiv.innerHTML = `<h3>${item.name}</h3><p>${item.description}</p>`;
+            if (item.history) {
+                infoDiv.innerHTML += `<p><strong>History:</strong> ${item.history}</p>`;
+            }
+            if (item.craftingInfo) {
+                infoDiv.innerHTML += `<p><strong>Real World Crafting:</strong> ${item.craftingInfo}</p>`;
+            }
+            if (item.effect) {
+                const list = Object.entries(item.effect)
+                    .map(([k,v]) => `<div>${k}: ${v}</div>`)
+                    .join('');
+                if (list) infoDiv.innerHTML += list;
+            }
+        } else {
+            infoDiv.innerHTML = `<p>Unlocked feature: ${puzzle.unlocks}</p>`;
+        }
+        nextBtn.disabled = gameState.currentBookIndex >= puzzles.length - 1;
+    } else {
+        infoDiv.style.display = 'none';
+        questionDiv.style.display = 'block';
+        document.getElementById('book-puzzle-text').textContent = puzzle.puzzle;
+        document.getElementById('book-answer').value = '';
+        nextBtn.disabled = true;
+    }
+}
+
+function submitAnswer() {
+    const puzzle = getCurrentPuzzle();
+    if (!puzzle) return;
+    const answer = document.getElementById('book-answer').value.toLowerCase().trim();
+    if (answer === puzzle.answer.toLowerCase()) {
+        if (!gameState.unlockedFeatures.includes(puzzle.unlocks)) {
+            gameState.unlockedFeatures.push(puzzle.unlocks);
+        }
+        gameState.knowledge += 1;
+        updateDisplay();
+        updateCraftableItems();
+        renderPage();
+    } else {
+        alert('Incorrect answer. Try again!');
+    }
+}
+
+function nextPage() {
+    const puzzles = getPuzzles();
+    if (gameState.currentBookIndex < puzzles.length - 1) {
+        gameState.currentBookIndex++;
+        renderPage();
+    }
+}
+
+function prevPage() {
+    if (gameState.currentBookIndex > 0) {
+        gameState.currentBookIndex--;
+        renderPage();
+    }
+}

--- a/android/app/src/main/assets/www/crafting.js
+++ b/android/app/src/main/assets/www/crafting.js
@@ -1,0 +1,145 @@
+import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
+import { logEvent, updateDisplay, updateWorkingSection } from './ui.js';
+import { checkAchievements } from './achievements.js';
+import { updateAutomationControls } from './automation.js';
+import { recordItemCraft } from './stats.js';
+
+const craftingQueue = [];
+
+export function updateCraftableItems() {
+    if (!gameState.unlockedFeatures.includes('crafting')) {
+        document.getElementById('crafting').style.display = 'none';
+        return;
+    }
+
+    document.getElementById('crafting').style.display = 'block';
+    const config = getConfig();
+    const craftableItemsContainer = document.getElementById('craftable-items');
+    craftableItemsContainer.innerHTML = '';
+    
+    config.items.forEach(item => {
+        if (!gameState.craftedItems[item.id] && gameState.unlockedFeatures.includes(item.id) && areDependenciesMet(item)) {
+            const canCraft = Object.entries(item.requirements).every(([resource, amount]) => gameState[resource] >= amount);
+            const button = document.createElement('button');
+            button.textContent = `Craft ${item.name} (${Object.entries(item.requirements).map(([resource, amount]) => `${amount} ${resource}`).join(', ')})`;
+            button.disabled = !canCraft || gameState.availableWorkers === 0;
+            button.addEventListener('click', () => startCrafting(item));
+            craftableItemsContainer.appendChild(button);
+        }
+    });
+}
+
+export function areDependenciesMet(item) {
+    return item.dependencies.every(depId => gameState.craftedItems[depId]);
+}
+
+function startCrafting(item) {
+    if (gameState.availableWorkers === 0) {
+        logEvent("No available workers to start crafting.");
+        return;
+    }
+
+    // Deduct resources except knowledge, which is not consumed
+    Object.entries(item.requirements).forEach(([resource, amount]) => {
+        if (resource !== 'knowledge') {
+            gameState[resource] -= amount;
+        }
+    });
+
+    adjustAvailableWorkers(-1);
+    gameState.craftingQueue.push({
+        item: item,
+        progress: 0,
+        duration: item.craftingTime
+    });
+
+    updateCraftableItems();
+    updateDisplay();
+    processQueue();
+}
+
+export function processQueue() {
+    if (gameState.craftingQueue.length === 0) return;
+
+    const currentCraft = gameState.craftingQueue[0];
+    gameState.currentWork = { type: 'crafting', item: currentCraft.item };
+    updateWorkingSection();
+
+    const progressInterval = setInterval(() => {
+        currentCraft.progress += 100;
+        updateWorkingSection(currentCraft.progress / currentCraft.duration);
+
+        if (currentCraft.progress >= currentCraft.duration) {
+            clearInterval(progressInterval);
+            completeCrafting(currentCraft.item);
+        }
+    }, 100);
+}
+
+function completeCrafting(item) {
+    // Store the full item data so other systems can access its effects
+    gameState.craftedItems[item.id] = item;
+    recordItemCraft(item.id);
+    logEvent(`Crafted ${item.name}!`);
+    
+    adjustAvailableWorkers(1);
+    gameState.currentWork = null;
+    gameState.craftingQueue.shift();
+    
+    updateCraftableItems();
+    updateDisplay();
+    updateWorkingSection();
+    updateAutomationControls();
+    gameState.craftCount += 1;
+    checkAchievements();
+
+    if (gameState.craftingQueue.length > 0) {
+        processQueue();
+    }
+}
+
+
+
+
+function updateCraftingQueue() {
+    const queueContainer = document.getElementById('crafting-queue');
+    queueContainer.innerHTML = '';
+    craftingQueue.forEach(craftingItem => {
+        const itemElement = document.createElement('div');
+        itemElement.className = 'crafting-item';
+        itemElement.innerHTML = `
+            <span>${craftingItem.item.name}</span>
+            <div class="progress-bar-container">
+                <div class="progress-bar"></div>
+            </div>
+        `;
+        queueContainer.appendChild(itemElement);
+    });
+}
+
+
+
+function craftItem(item) {
+    // Only deduct expendable resources. Knowledge acts as a threshold
+    // and should never decrease.
+    Object.entries(item.requirements).forEach(([resource, amount]) => {
+        if (resource !== 'knowledge') {
+            gameState[resource] -= amount;
+        }
+    });
+    gameState.craftedItems[item.id] = item;
+    logEvent(`Crafted ${item.name}!`);
+    updateDisplay();
+    updateCraftableItems();
+    updateAutomationControls();
+}
+
+// Make sure showPuzzle is exported
+export function showPuzzle(item) {
+    const puzzlePopup = document.getElementById('puzzle-popup');
+    document.getElementById('puzzle-title').textContent = `Craft ${item.name}`;
+    document.getElementById('puzzle-description').textContent = item.puzzle;
+    document.getElementById('puzzle-answer').value = '';
+    puzzlePopup.style.display = 'block';
+    puzzlePopup.dataset.itemId = item.id;
+}

--- a/android/app/src/main/assets/www/events.js
+++ b/android/app/src/main/assets/www/events.js
@@ -1,0 +1,78 @@
+import { gameState, getConfig } from './gameState.js';
+import { logEvent, updateDisplay, showEventPopup } from './ui.js';
+import { recordResourceGain } from './stats.js';
+
+let activeEvents = [];
+
+export function checkForEvents() {
+    const config = getConfig();
+    config.events.forEach(event => {
+        if (Math.random() < event.probability && !activeEvents.some(e => e.id === event.id)) {
+            triggerEvent(event);
+        }
+    });
+}
+
+function triggerEvent(event) {
+    logEvent(`Event: ${event.name} - ${event.description}`);
+    showEventPopup(event);
+
+    Object.entries(event.effect).forEach(([key, value]) => {
+        if (key in gameState) {
+            gameState[key] += value;
+            if (value > 0) recordResourceGain(key, value);
+        } else if (key === 'gatheringEfficiency') {
+            // Store the efficiency modifier
+            gameState.gatheringEfficiency = (gameState.gatheringEfficiency || 1) * value;
+        }
+    });
+
+    if (event.duration) {
+        const config = getConfig();
+        const durationSeconds = event.duration * config.constants.DAY_LENGTH;
+        activeEvents.push({ ...event, remainingDuration: durationSeconds });
+    }
+
+    updateDisplay();
+}
+
+export function advanceEventTime(seconds) {
+    activeEvents = activeEvents.filter(event => {
+        event.remainingDuration -= seconds;
+        if (event.remainingDuration <= 0) {
+            endEvent(event);
+            return false;
+        }
+        return true;
+    });
+}
+
+export function updateActiveEvents(seconds = 1) {
+    advanceEventTime(seconds);
+}
+
+export function hasActiveEvents() {
+    return activeEvents.length > 0;
+}
+
+function endEvent(event) {
+    logEvent(`The effects of "${event.name}" have worn off.`);
+    
+    // Reverse the effects
+    Object.entries(event.effect).forEach(([key, value]) => {
+        if (key === 'gatheringEfficiency') {
+            gameState.gatheringEfficiency /= value;
+        }
+        // For other effects, we don't reverse them as they were one-time bonuses
+    });
+
+    updateDisplay();
+}
+
+export function triggerRandomEvent() {
+    const config = getConfig();
+    const events = config.events;
+    if (events.length === 0) return;
+    const event = events[Math.floor(Math.random() * events.length)];
+    triggerEvent(event);
+}

--- a/android/app/src/main/assets/www/expeditions.js
+++ b/android/app/src/main/assets/www/expeditions.js
@@ -1,0 +1,70 @@
+import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
+import { logEvent } from './ui.js';
+import { recordResourceGain } from './stats.js';
+import { triggerRandomEvent } from './events.js';
+
+export function initExpeditions() {
+    const btn = document.getElementById('start-expedition');
+    if (btn) {
+        btn.addEventListener('click', startExpedition);
+    }
+    updateExpeditionUI();
+}
+
+export function startExpedition() {
+    if (gameState.availableWorkers <= 0) {
+        logEvent('No available workers for an expedition.');
+        return;
+    }
+    const config = getConfig();
+    const duration = config.constants.EXPEDITION_DURATION || 30;
+    gameState.expeditions.push({ remaining: duration });
+    adjustAvailableWorkers(-1);
+    logEvent('An expedition has set out.');
+    updateExpeditionUI();
+}
+
+function completeExpedition() {
+    adjustAvailableWorkers(1);
+    const config = getConfig();
+    if (Math.random() < 0.2) {
+        triggerRandomEvent();
+    } else {
+        const rewards = config.resources;
+        const resource = rewards[Math.floor(Math.random() * rewards.length)];
+        const amount = Math.round(Math.random() * 5 + 5);
+        gameState[resource] = (gameState[resource] || 0) + amount;
+        recordResourceGain(resource, amount);
+        logEvent(`Expedition returned with ${amount} ${resource}.`);
+    }
+}
+
+export function updateExpeditions(seconds = 1) {
+    const completed = [];
+    gameState.expeditions.forEach(exp => {
+        exp.remaining -= seconds;
+        if (exp.remaining <= 0) completed.push(exp);
+    });
+    completed.forEach(exp => {
+        completeExpedition();
+    });
+    if (completed.length > 0) {
+        gameState.expeditions = gameState.expeditions.filter(e => e.remaining > 0);
+        updateExpeditionUI();
+    }
+}
+
+export function hasExpeditions() {
+    return gameState.expeditions.length > 0;
+}
+
+function updateExpeditionUI() {
+    const list = document.getElementById('expedition-list');
+    if (!list) return;
+    list.innerHTML = '';
+    gameState.expeditions.forEach((exp, index) => {
+        const li = document.createElement('div');
+        li.textContent = `Expedition ${index + 1}: ${exp.remaining}s remaining`;
+        list.appendChild(li);
+    });
+}

--- a/android/app/src/main/assets/www/game.js
+++ b/android/app/src/main/assets/www/game.js
@@ -1,0 +1,300 @@
+import { gameState, loadGameConfig, getConfig, getPrestigeMultiplier } from './gameState.js';
+import { updateDisplay, updateTimeDisplay, updateTimeEmoji, logEvent, submitUnlockPuzzleAnswer, closePuzzlePopup, openSettingsMenu, closeSettingsMenu, updateGatherButtons } from './ui.js';
+import { gatherResource, scavenge, consumeResources, logDailyConsumption, produceResources, checkPopulationGrowth, trainWorker } from './resources.js';
+import { updateCraftableItems, processQueue } from './crafting.js';
+import { updateAutomationControls, runAutomation, hasActiveAutomation } from './automation.js';
+import { prestigeGame, resetState } from './prestige.js';
+import { checkForEvents, updateActiveEvents, advanceEventTime, hasActiveEvents } from './events.js';
+import { initBook } from './book.js';
+import { initAchievements } from './achievements.js';
+import { startTutorial, checkTutorialProgress, nextStep, skipTutorial } from './tutorial.js';
+import { recordResourceGain } from './stats.js';
+import { initExpeditions, updateExpeditions, hasExpeditions } from './expeditions.js';
+
+function saveGame(manual = false) {
+    gameState.lastSaved = Date.now();
+    localStorage.setItem('afkGameSave', JSON.stringify(gameState));
+    if (manual) {
+        logEvent('Game saved');
+    }
+}
+
+function loadSavedGame() {
+    const saved = localStorage.getItem('afkGameSave');
+    if (saved) {
+        Object.assign(gameState, JSON.parse(saved));
+    }
+}
+
+function applyOfflineProgress() {
+    const config = getConfig();
+    if (!gameState.lastSaved) {
+        gameState.lastSaved = Date.now();
+        return;
+    }
+    const now = Date.now();
+    const elapsed = Math.floor((now - gameState.lastSaved) / 1000);
+    if (elapsed <= 0) return;
+
+    const limit = config.constants.OFFLINE_PROGRESS_LIMIT || 28800;
+    const seconds = Math.min(elapsed, limit);
+
+    consumeResources(seconds);
+
+    const cycles = Math.floor(seconds / 10);
+    const mult = getPrestigeMultiplier();
+    Object.entries(gameState.automationAssignments).forEach(([itemId, count]) => {
+        if (count <= 0) return;
+        if (itemId.startsWith('gather_')) {
+            const resource = itemId.replace('gather_', '');
+            const gained = count * cycles * mult;
+            gameState[resource] = (gameState[resource] || 0) + gained;
+            recordResourceGain(resource, gained);
+        } else {
+            const item = config.items.find(i => i.id === itemId);
+            if (item && item.effect) {
+                Object.keys(item.effect).forEach(key => {
+                    if (key.endsWith('ProductionRate')) {
+                        const resource = key.replace('ProductionRate', '');
+                        const gained = count * cycles * mult;
+                        gameState[resource] = (gameState[resource] || 0) + gained;
+                        recordResourceGain(resource, gained);
+                        if (resource === 'food' || resource === 'water') {
+                            gameState[resource] = Math.min(100, gameState[resource]);
+                        }
+                    }
+                });
+            }
+        }
+    });
+
+    const totalTime = gameState.time + seconds;
+    const daysPassed = Math.floor(totalTime / config.constants.DAY_LENGTH);
+    gameState.time = totalTime % config.constants.DAY_LENGTH;
+    gameState.day += daysPassed;
+    gameState.daysSinceGrowth += daysPassed;
+
+    for (let i = 0; i < daysPassed; i++) {
+        logDailyConsumption();
+        produceResources();
+        checkPopulationGrowth();
+        checkForEvents();
+        advanceEventTime(config.constants.DAY_LENGTH);
+    }
+
+    const prevSeason = gameState.seasonIndex;
+    const daysPerSeason = config.constants.DAYS_PER_SEASON || 30;
+    gameState.seasonIndex = Math.floor((gameState.day - 1) / daysPerSeason) % config.seasons.length;
+    if (gameState.seasonIndex !== prevSeason) {
+        logEvent(`The season has changed to ${config.seasons[gameState.seasonIndex].name}.`);
+    }
+
+    const remaining = seconds - daysPassed * config.constants.DAY_LENGTH;
+    if (remaining > 0) {
+        advanceEventTime(remaining);
+    }
+
+    checkSurvival();
+    gameState.lastSaved = now;
+}
+
+async function initializeGame() {
+    await loadGameConfig();
+    loadSavedGame();
+    applyOfflineProgress();
+    const config = getConfig();
+
+    updateCraftableItems();
+    updateAutomationControls();
+    createGatheringActions(config.resources);
+    updateGatherButtons();
+    initBook();
+    initAchievements();
+    initExpeditions();
+    updateDisplay();
+    checkForEvents();
+
+    // Event listeners
+    // config.resources.forEach(resource => {
+    //     document.getElementById(`gather-${resource}`).addEventListener('click', () => gatherResource(resource));
+    // });
+    document.getElementById('submit-puzzle').addEventListener('click', submitUnlockPuzzleAnswer);
+    document.getElementById('close-puzzle').addEventListener('click', closePuzzlePopup);
+    document.getElementById('settings-btn').addEventListener('click', openSettingsMenu);
+    document.getElementById('close-settings').addEventListener('click', closeSettingsMenu);
+    const saveBtn = document.getElementById('save-game-btn');
+    if (saveBtn) {
+        saveBtn.addEventListener('click', () => saveGame(true));
+    }
+    const prestigeBtn = document.getElementById('prestige-btn');
+    if (prestigeBtn) {
+        prestigeBtn.addEventListener('click', prestigeGame);
+    }
+    const trainBtn = document.getElementById('train-worker-btn');
+    if (trainBtn) {
+        trainBtn.addEventListener('click', trainWorker);
+    }
+
+    // Bottom navigation
+    document.querySelectorAll('#bottom-nav .nav-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('#bottom-nav .nav-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            const target = btn.dataset.target;
+            document.querySelectorAll('.game-section').forEach(sec => sec.classList.remove('game-section-active'));
+            document.getElementById(target).classList.add('game-section-active');
+        });
+    });
+
+    // Tutorial buttons
+    const nextBtn = document.getElementById('tutorial-next');
+    const skipBtn = document.getElementById('tutorial-skip');
+    if (nextBtn) nextBtn.addEventListener('click', nextStep);
+    if (skipBtn) skipBtn.addEventListener('click', skipTutorial);
+
+    startTutorial();
+
+    // Start game loop
+    lastLoop = Date.now();
+    scheduleNextLoop();
+    setInterval(saveGame, 30000); // Auto-save every 30 seconds
+}
+
+function createGatheringActions(resources) {
+    const actionsContainer = document.getElementById('actions');
+    //actionsContainer.innerHTML = ''; // Clear existing content
+
+    resources.forEach(resource => {
+        const gatherAction = document.createElement('div');
+        gatherAction.className = 'gather-action';
+
+        const button = document.createElement('button');
+        button.id = `gather-${resource}`;
+        button.className = 'progress-button';
+        const textSpan = document.createElement('span');
+        textSpan.textContent = `Gather ${resource.charAt(0).toUpperCase() + resource.slice(1)}`;
+        button.appendChild(textSpan);
+        const multSpan = document.createElement('span');
+        multSpan.className = 'multiplier';
+        button.appendChild(multSpan);
+
+        const progressBar = document.createElement('div');
+        progressBar.id = `${resource}-progress-bar`;
+        progressBar.className = 'progress-bar';
+        button.appendChild(progressBar);
+
+        button.addEventListener('click', () => gatherResource(resource));
+
+        gatherAction.appendChild(button);
+        actionsContainer.appendChild(gatherAction);
+    });
+
+    // Scavenge mini-game button
+    const scavengeAction = document.createElement('div');
+    scavengeAction.className = 'gather-action';
+    const scavengeBtn = document.createElement('button');
+    scavengeBtn.id = 'scavenge';
+    scavengeBtn.className = 'progress-button';
+    scavengeBtn.innerHTML = '<span>Scavenge Ruins</span>';
+    const scavengeBar = document.createElement('div');
+    scavengeBar.className = 'progress-bar';
+    scavengeBtn.appendChild(scavengeBar);
+    scavengeBtn.addEventListener('click', scavenge);
+    scavengeAction.appendChild(scavengeBtn);
+    actionsContainer.appendChild(scavengeAction);
+}
+
+function gameLoop(delta) {
+    const daysPassed = updateTime(delta);
+    consumeResources(delta);
+    for (let i = 0; i < daysPassed; i++) {
+        logDailyConsumption();
+        produceResources();
+        checkPopulationGrowth();
+        checkForEvents();
+    }
+    runAutomation(delta);
+    updateActiveEvents(delta);
+    updateExpeditions(delta);
+    checkSurvival();
+    checkTutorialProgress();
+    updateDisplay();
+    processQueue();
+}
+
+function updateTime(seconds) {
+    const config = getConfig();
+    const totalTime = gameState.time + seconds;
+    const dayLength = config.constants.DAY_LENGTH;
+    const daysPassed = Math.floor(totalTime / dayLength);
+    gameState.time = totalTime % dayLength;
+    if (daysPassed > 0) {
+        gameState.day += daysPassed;
+        gameState.daysSinceGrowth += daysPassed;
+        checkSeasonChange();
+    }
+    updateTimeEmoji();
+    updateTimeDisplay();
+    return daysPassed;
+}
+
+function checkSeasonChange() {
+    const config = getConfig();
+    const days = config.constants.DAYS_PER_SEASON || 30;
+    if ((gameState.day - 1) % days === 0 && gameState.day !== 1) {
+        gameState.seasonIndex = (gameState.seasonIndex + 1) % config.seasons.length;
+        const season = config.seasons[gameState.seasonIndex].name;
+        logEvent(`The season has changed to ${season}.`);
+    }
+}
+
+function checkSurvival() {
+    if (gameState.food <= 0 || gameState.water <= 0) {
+        alert('Game Over! Your population did not survive.');
+        resetGame();
+    }
+}
+
+function resetGame() {
+    resetState();
+    updateDisplay();
+    updateCraftableItems();
+    updateAutomationControls();
+}
+
+let lastLoop = 0;
+
+function isGameActive() {
+    return (
+        gameState.currentWork ||
+        hasActiveAutomation() ||
+        hasActiveEvents() ||
+        hasExpeditions()
+    );
+}
+
+function getUpdateInterval() {
+    return isGameActive() ? 1000 : 5000;
+}
+
+function gameLoopWrapper() {
+    const now = Date.now();
+    const delta = (now - lastLoop) / 1000;
+    lastLoop = now;
+    gameLoop(delta);
+    scheduleNextLoop();
+}
+
+function scheduleNextLoop() {
+    setTimeout(gameLoopWrapper, getUpdateInterval());
+}
+
+async function startGame() {
+    const loading = document.getElementById('loading-screen');
+    if (loading) loading.style.display = 'flex';
+    await initializeGame();
+    if (loading) loading.style.display = 'none';
+}
+
+// Initialize the game
+startGame();

--- a/android/app/src/main/assets/www/gameState.js
+++ b/android/app/src/main/assets/www/gameState.js
@@ -72,7 +72,3 @@ export function getPrestigeMultiplier() {
     });
     return mult;
 }
-
-export function setGameConfig(config) {
-    gameConfig = config;
-}

--- a/android/app/src/main/assets/www/index.html
+++ b/android/app/src/main/assets/www/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#1e1e2f">
+    <title>Advanced Survival and Civilization Rebuilder</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.1/css/all.min.css">
+</head>
+<body>
+    <div id="loading-screen">Loading...</div>
+    <div id="game-container">
+        <div id="top-section">
+            <div id="day-night-cycle">
+                
+                <div id="time-section"> 
+                    <div id="time-emoji">🌅</div> 
+                     <div id="time-area">
+                         <div id="time-day">Day: <span id="day-count">1</span></div> | <div id="time-time">Time: <span id="time-display">00:00</span></div>
+                     </div>
+                     <div id="time-season">Season: <span id="current-season">Spring</span></div>
+                </div>
+                <div id="population">
+                    <div class="population-info">
+                        <i class="fas fa-users"></i>
+                        <p>Pop: <span id="population-count">1</span></p>
+                    </div>
+                    <div class="population-info">
+                        <i class="fas fa-user-tie"></i>
+                        <p>Workers: <span id="available-workers">0</span>/<span id="total-workers">0</span></p>
+                    </div>
+                    <button id="train-worker-btn">Train Worker</button>
+                </div>
+            </div>
+            <div id="resources">
+                <div class="resource-item">
+                    <i class="fas fa-utensils"></i>
+                    <span id="food">100</span>
+                    <progress id="food-bar" value="100" max="100"></progress>
+                </div>
+            <div class="resource-item">
+                <i class="fas fa-water"></i>
+                <span id="water">100</span>
+                <progress id="water-bar" value="100" max="100"></progress>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-tree"></i>
+                <span id="wood">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-mountain"></i>
+                <span id="stone">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-book"></i>
+                <span id="knowledge">2</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-cubes"></i>
+                <span id="clay">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-spa"></i>
+                <span id="fiber">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-gem"></i>
+                <span id="ore">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-leaf"></i>
+                <span id="herbs">0</span>
+            </div>
+            <div class="resource-item">
+                <i class="fas fa-apple-alt"></i>
+                <span id="fruit">0</span>
+            </div>
+        </div>
+        </div>
+        <div id="actions" class="game-section game-section-active">
+             <!-- Gathering buttons will be dynamically inserted here -->
+        </div>
+        <div id="book" class="game-section">
+            <h2>Study Book</h2>
+            <div id="book-page">
+                <div id="book-question">
+                    <p id="book-puzzle-text"></p>
+                    <input type="text" id="book-answer" placeholder="Answer">
+                    <button id="book-submit">Submit</button>
+                </div>
+                <div id="book-item-info" style="display:none;"></div>
+            </div>
+            <div id="book-nav-container">
+                <button id="book-prev" class="book-nav">&larr;</button>
+                <button id="book-next" class="book-nav">&rarr;</button>
+            </div>
+        </div>
+        <div id="crafting" class="game-section">
+            <h2>Crafting</h2>
+            <div id="craftable-items"></div>
+            <h3>Crafting Queue</h3>
+            <div id="crafting-queue"></div>
+        </div>
+        <div id="automation" class="game-section">
+            <h2>Automation</h2>
+            <div id="automation-controls"></div>
+        </div>
+        <div id="expeditions" class="game-section">
+            <h2>Expeditions</h2>
+            <button id="start-expedition" class="progress-button">Start Expedition</button>
+            <div id="expedition-list"></div>
+        </div>
+        <div id="stats" class="game-section">
+            <h2>Statistics</h2>
+            <div id="stats-content"></div>
+        </div>
+        <div id="achievements" class="game-section">
+            <h2>Achievements</h2>
+            <ul id="achievement-list"></ul>
+        </div>
+        <div id="log" class="game-section">
+            <h2>Event Log</h2>
+            <ul id="event-log"></ul>
+            <div id="population-progress">
+                <h3>Population Progress</h3>
+                <ul id="growth-requirements" class="requirements-list"></ul>
+            </div>
+        </div>
+    </div>
+
+    <nav id="bottom-nav">
+        <button class="nav-btn active" data-target="actions"><i class="fas fa-hand-paper"></i><span>Gather</span></button>
+        <button class="nav-btn" data-target="crafting"><i class="fas fa-hammer"></i><span>Craft</span></button>
+        <button class="nav-btn" data-target="automation"><i class="fas fa-robot"></i><span>Auto</span></button>
+        <button class="nav-btn" data-target="expeditions"><i class="fas fa-compass"></i><span>Exped</span></button>
+        <button class="nav-btn" data-target="book"><i class="fas fa-book-open"></i><span>Book</span></button>
+        <button class="nav-btn" data-target="stats"><i class="fas fa-chart-bar"></i><span>Stats</span></button>
+        <button class="nav-btn" data-target="achievements"><i class="fas fa-trophy"></i><span>Achieve</span></button>
+        <button class="nav-btn" data-target="log"><i class="fas fa-list"></i><span>Log</span></button>
+        <button class="nav-btn" id="settings-btn"><i class="fas fa-ellipsis-v"></i><span>Info</span></button>
+    </nav>
+
+    <div id="puzzle-popup" class="popup">
+        <h2 id="puzzle-title"></h2>
+        <p id="puzzle-description"></p>
+        <input type="text" id="puzzle-answer" placeholder="Enter your answer">
+        <button id="submit-puzzle">Submit Answer</button>
+        <button id="close-puzzle">Close</button>
+    </div>
+
+    <div id="event-popup" class="popup">
+        <h2 id="event-name"></h2>
+        <p id="event-description"></p>
+    </div>
+
+    <div id="achievement-popup" class="popup"></div>
+
+    <div id="tutorial-overlay" class="popup">
+        <p id="tutorial-text"></p>
+        <button id="tutorial-next">Next</button>
+        <button id="tutorial-skip">Skip</button>
+    </div>
+
+    <div id="settings-menu" class="popup">
+        <h2>Settings</h2>
+        <p id="game-title">Advanced Survival and Civilization Rebuilder</p>
+        <button id="save-game-btn">Save Game</button>
+        <p>Prestige Points: <span id="prestige-points">0</span></p>
+        <button id="prestige-btn">Prestige</button>
+        <button id="close-settings">Close</button>
+    </div>
+
+    <script type="module" src="game.js"></script>
+</body>
+</html>

--- a/android/app/src/main/assets/www/knowledge_data.json
+++ b/android/app/src/main/assets/www/knowledge_data.json
@@ -1,0 +1,1587 @@
+{
+  "resources": [
+    "food",
+    "water",
+    "wood",
+    "stone",
+    "clay",
+    "fiber",
+    "ore",
+    "herbs",
+    "fruit"
+  ],
+  "initialState": {
+    "food": 100,
+    "water": 100,
+    "wood": 0,
+    "stone": 0,
+    "clay": 0,
+    "fiber": 0,
+    "ore": 0,
+    "herbs": 0,
+    "fruit": 0,
+    "knowledge": 0,
+    "population": 1,
+    "workers": 1,
+    "day": 1,
+    "time": 0,
+    "gatherCount": 0,
+    "studyCount": 0,
+    "craftCount": 0,
+    "daysSinceGrowth": 0,
+    "seasonIndex": 0,
+    "expeditions": [],
+    "automationProgress": {},
+    "lastSaved": 0,
+    "prestigePoints": 0,
+    "achievements": {},
+    "stats": {
+      "resourcesGathered": {},
+      "itemsCrafted": {}
+    }
+  },
+  "constants": {
+    "DAY_LENGTH": 600,
+    "DAY_PHASE": 300,
+    "POPULATION_THRESHOLD": 40,
+    "POPULATION_GROWTH_DAYS": 2,
+    "POPULATION_GATHER_REQUIRED": 3,
+    "POPULATION_STUDY_REQUIRED": 1,
+    "POPULATION_CRAFT_REQUIRED": 1,
+    "POPULATION_GROWTH_COST": 5,
+    "OFFLINE_PROGRESS_LIMIT": 28800,
+    "EXPEDITION_DURATION": 30,
+    "DAYS_PER_SEASON": 10
+  },
+  "gatheringTimes": {
+    "wood": 5000,
+    "stone": 7000,
+    "food": 3000,
+    "water": 2000,
+    "clay": 6000,
+    "fiber": 4000,
+    "ore": 8000,
+    "herbs": 5000,
+    "fruit": 4000
+  },
+  "seasons": [
+    { "name": "Spring", "gatheringEfficiency": 1.1, "consumption": 1, "production": 1.1 },
+    { "name": "Summer", "gatheringEfficiency": 1, "consumption": 1.2, "production": 1 },
+    { "name": "Autumn", "gatheringEfficiency": 1.2, "consumption": 0.9, "production": 1.2 },
+    { "name": "Winter", "gatheringEfficiency": 0.8, "consumption": 1.3, "production": 0.8 }
+  ],
+  "unlockPuzzles": [
+    {
+      "id": "unlock_crafting",
+      "puzzle": "I am the art of making, combining elements anew. What am I?",
+      "answer": "crafting",
+      "unlocks": "crafting"
+    },
+    {
+      "id": "unlock_fire",
+      "puzzle": "I dance and glow, bringing warmth and light through the night. What am I?",
+      "answer": "fire",
+      "unlocks": "fire"
+    },
+    {
+      "id": "unlock_axe",
+      "puzzle": "I have a head and a handle that fits, to chop and split I'm hard to beat. What am I?",
+      "answer": "axe",
+      "unlocks": "axe"
+    },
+    {
+      "id": "unlock_shelter",
+      "puzzle": "I protect you from the elements, a haven from the storm. What am I?",
+      "answer": "shelter",
+      "unlocks": "shelter"
+    },
+    {
+      "id": "unlock_knife",
+      "puzzle": "I'm sharp and handy, cut and slice, in survival I'm worth my price.",
+      "answer": "knife",
+      "unlocks": "knife"
+    },
+    {
+      "id": "unlock_pickaxe",
+      "puzzle": "I have a point and a rocky mission, breaking through stone is my ambition.",
+      "answer": "pickaxe",
+      "unlocks": "pickaxe"
+    },
+    {
+      "id": "unlock_farm",
+      "puzzle": "With seeds and soil, sun and rain, I help your food to grow again. What am I?",
+      "answer": "farm",
+      "unlocks": "farm"
+    },
+    {
+      "id": "unlock_well",
+      "puzzle": "Deep in the earth, I'm built with care, to bring up something vital and rare. What am I?",
+      "answer": "well",
+      "unlocks": "well"
+    },
+    {
+      "id": "unlock_fishing_rod",
+      "puzzle": "I'm long and thin, with a hook at the end, I help you catch dinner, I'm your aquatic friend.",
+      "answer": "fishing rod",
+      "unlocks": "fishing_rod"
+    },
+    {
+      "id": "unlock_kiln",
+      "puzzle": "I'm hot inside, turning soft to hard, with me you can shape clay, I'm a crafter's card.",
+      "answer": "kiln",
+      "unlocks": "kiln"
+    },
+    {
+      "id": "unlock_loom",
+      "puzzle": "Threads intertwine, as I work back and forth, creating fabric fine, I prove my worth.",
+      "answer": "loom",
+      "unlocks": "loom"
+    },
+    {
+      "id": "unlock_forge",
+      "puzzle": "Fire burns hot, metal bends to will, I shape the future, with hammer and skill.",
+      "answer": "forge",
+      "unlocks": "forge"
+    },
+    {
+      "id": "unlock_herbalist_hut",
+      "puzzle": "Leaves and roots, I know their use, to heal the sick, my knowledge I produce.",
+      "answer": "herbalist's hut",
+      "unlocks": "herbalist_hut"
+    },
+    {
+      "id": "unlock_watchtower",
+      "puzzle": "I stand tall and see far, guarding day and night, from my peak, everything's in sight.",
+      "answer": "watchtower",
+      "unlocks": "watchtower"
+    },
+    {
+      "id": "unlock_storehouse",
+      "puzzle": "Walls and roof, I keep things dry, your goods within, safe and spry.",
+      "answer": "storehouse",
+      "unlocks": "storehouse"
+    },
+    {
+      "id": "unlock_orchard",
+      "puzzle": "Trees in rows, bearing sweet delight, I grow your food, from dawn to night.",
+      "answer": "orchard",
+      "unlocks": "orchard"
+    },
+    {
+      "id": "unlock_tannery",
+      "puzzle": "Hides I treat, with skill and care, turning skin to leather, strong and fair.",
+      "answer": "tannery",
+      "unlocks": "tannery"
+    },
+    {
+      "id": "unlock_library",
+      "puzzle": "Words on pages, knowledge stored, in my halls, wisdom is explored.",
+      "answer": "library",
+      "unlocks": "library"
+    },
+    {
+      "id": "unlock_pottery_workshop",
+      "puzzle": "With wheel and hand, I shape the clay, creating vessels for use each day.",
+      "answer": "pottery workshop",
+      "unlocks": "pottery_workshop"
+    },
+    {
+      "id": "unlock_hunting_lodge",
+      "puzzle": "In forest deep, I track and stalk, to bring back meat, on which we'll not balk.",
+      "answer": "hunting lodge",
+      "unlocks": "hunting_lodge"
+    },
+    {
+      "id": "unlock_quarry",
+      "puzzle": "I dig deep into the mountain's heart, to bring forth riches, stone and ore to impart.",
+      "answer": "quarry",
+      "unlocks": "quarry"
+    },
+    {
+      "id": "unlock_weaving_mill",
+      "puzzle": "Shuttles fly, threads entwine, creating fabric, line by line.",
+      "answer": "weaving mill",
+      "unlocks": "weaving_mill"
+    },
+    {
+      "id": "unlock_apothecary",
+      "puzzle": "Potions and tinctures, I brew with care, to cure the sick and health repair.",
+      "answer": "apothecary",
+      "unlocks": "apothecary"
+    },
+    {
+      "id": "unlock_marketplace",
+      "puzzle": "Goods are bought and sold with glee, in this place of commerce and trade you'll see.",
+      "answer": "marketplace",
+      "unlocks": "marketplace"
+    },
+    {
+      "id": "unlock_sawmill",
+      "puzzle": "Blades whir and timber falls, transforming trees to planks for walls.",
+      "answer": "sawmill",
+      "unlocks": "sawmill"
+    },
+    {
+      "id": "unlock_school",
+      "puzzle": "Young minds gather, to learn and grow, in this place of learning, knowledge to sow.",
+      "answer": "school",
+      "unlocks": "school"
+    },
+    {
+      "id": "unlock_windmill",
+      "puzzle": "My arms reach high, catching the breeze, grinding the grain with the greatest of ease.",
+      "answer": "windmill",
+      "unlocks": "windmill"
+    },
+    {
+      "id": "unlock_observatory",
+      "puzzle": "Gazing at stars, secrets unfold, in this tower of science, discoveries bold.",
+      "answer": "observatory",
+      "unlocks": "observatory"
+    },
+    {
+      "id": "unlock_glassworks",
+      "puzzle": "From sand to liquid, then cooled with care, I create clear panes beyond compare.",
+      "answer": "glassworks",
+      "unlocks": "glassworks"
+    },
+    {
+      "id": "unlock_brewery",
+      "puzzle": "Bubbling vats and aging casks, I create drinks for all tasks.",
+      "answer": "brewery",
+      "unlocks": "brewery"
+    },
+    {
+      "id": "unlock_blacksmith",
+      "puzzle": "With hammer and anvil, I shape the ore, creating tools not seen before.",
+      "answer": "blacksmith",
+      "unlocks": "blacksmith"
+    },
+    {
+      "id": "unlock_granary",
+      "puzzle": "Tall and round, I stand with pride, keeping the harvest safe inside.",
+      "answer": "granary",
+      "unlocks": "granary"
+    },
+    {
+      "id": "unlock_textile_mill",
+      "puzzle": "Spinning wheels and clattering looms, I weave fine cloth in many rooms.",
+      "answer": "textile mill",
+      "unlocks": "textile_mill"
+    },
+    {
+      "id": "unlock_scriptorium",
+      "puzzle": "Quills scratch and pages turn, preserving knowledge for all to learn.",
+      "answer": "scriptorium",
+      "unlocks": "scriptorium"
+    },
+    {
+      "id": "unlock_alchemist_lab",
+      "puzzle": "Bubbling flasks and smoky air, I seek truths both dark and fair.",
+      "answer": "alchemist's laboratory",
+      "unlocks": "alchemist_lab"
+    },
+    {
+      "id": "unlock_shipyard",
+      "puzzle": "By river or sea, my creations sail free, bringing wealth from lands across the sea.",
+      "answer": "shipyard",
+      "unlocks": "shipyard"
+    },
+    {
+      "id": "unlock_university",
+      "puzzle": "Halls of learning, minds alight, I push the boundaries of wrong and right.",
+      "answer": "university",
+      "unlocks": "university"
+    },
+    {
+      "id": "unlock_monument",
+      "puzzle": "Towering high for all to see, I mark achievements of our society.",
+      "answer": "monument",
+      "unlocks": "monument"
+    },
+    {
+      "id": "unlock_irrigation_system",
+      "puzzle": "Channels and pipes, I guide the flow, helping crops to thrive and grow.",
+      "answer": "irrigation system",
+      "unlocks": "irrigation_system"
+    },
+    {
+      "id": "unlock_lighthouse",
+      "puzzle": "Tall I stand by waters deep, guiding ships while others sleep.",
+      "answer": "lighthouse",
+      "unlocks": "lighthouse"
+    },
+    {
+      "id": "unlock_paper_mill",
+      "puzzle": "Pulp and press, sheets so fine, on me your words will soon align.",
+      "answer": "paper mill",
+      "unlocks": "paper_mill"
+    },
+    {
+      "id": "unlock_mint",
+      "puzzle": "Metal discs I stamp with care, creating wealth beyond compare.",
+      "answer": "mint",
+      "unlocks": "mint"
+    },
+    {
+      "id": "unlock_aqueduct",
+      "puzzle": "Arches high, water flows, bringing life where'er it goes.",
+      "answer": "aqueduct",
+      "unlocks": "aqueduct"
+    },
+    {
+      "id": "unlock_theater",
+      "puzzle": "On my stage, stories unfold, entertaining young and old.",
+      "answer": "theater",
+      "unlocks": "theater"
+    },
+    {
+      "id": "unlock_telescope",
+      "puzzle": "Through me gaze at stars so far, unlocking secrets of what they are.",
+      "answer": "telescope",
+      "unlocks": "telescope"
+    },
+    {
+      "id": "unlock_printing_press",
+      "puzzle": "Letters arranged in lines so neat, I make copies quick and fleet.",
+      "answer": "printing press",
+      "unlocks": "printing_press"
+    },
+    {
+      "id": "unlock_music_hall",
+      "puzzle": "Melodies and harmonies resound, bringing joy to all around.",
+      "answer": "music hall",
+      "unlocks": "music_hall"
+    },
+    {
+      "id": "unlock_bank",
+      "puzzle": "Gold and silver, notes and coins, I guard them well in secure loins.",
+      "answer": "bank",
+      "unlocks": "bank"
+    },
+    {
+      "id": "unlock_courthouse",
+      "puzzle": "Justice served with balanced scales, here the law never fails.",
+      "answer": "courthouse",
+      "unlocks": "courthouse"
+    },
+    {
+      "id": "unlock_factory",
+      "puzzle": "Wheels turn and belts convey, producing goods day by day.",
+      "answer": "factory",
+      "unlocks": "factory"
+    },
+    {
+      "id": "unlock_hospital",
+      "puzzle": "In my wards, the sick find care, healing hands and knowledge rare.",
+      "answer": "hospital",
+      "unlocks": "hospital"
+    },
+    {
+      "id": "unlock_power_plant",
+      "puzzle": "Turbines spin with mighty force, providing power from nature's source.",
+      "answer": "power plant",
+      "unlocks": "power_plant"
+    },
+    {
+      "id": "unlock_railway",
+      "puzzle": "On iron rails I swiftly glide, carrying goods from side to side.",
+      "answer": "railway",
+      "unlocks": "railway"
+    },
+    {
+      "id": "unlock_stock_exchange",
+      "puzzle": "Bulls and bears, they come and go, as numbers rise and fall in show.",
+      "answer": "stock exchange",
+      "unlocks": "stock_exchange"
+    },
+    {
+      "id": "unlock_assembly_line",
+      "puzzle": "Step by step, piece by piece, production speed I will increase.",
+      "answer": "assembly line",
+      "unlocks": "assembly_line"
+    },
+    {
+      "id": "unlock_research_lab",
+      "puzzle": "In test tubes and under microscope, I seek answers and foster hope.",
+      "answer": "research laboratory",
+      "unlocks": "research_lab"
+    },
+    {
+      "id": "unlock_metropolis",
+      "puzzle": "Towers high and streets so wide, a bustling hub where millions reside.",
+      "answer": "metropolis",
+      "unlocks": "metropolis"
+    },
+    {
+      "id": "unlock_space_program",
+      "puzzle": "Beyond the sky, to stars we fly, in metal birds that pierce the sky.",
+      "answer": "space program",
+      "unlocks": "space_program"
+    }
+  ],
+  "events": [
+    {
+      "id": "bountiful_harvest",
+      "name": "Bountiful Harvest",
+      "description": "An unexpectedly good harvest provides extra food.",
+      "effect": {
+        "food": 50
+      },
+      "probability": 0.1
+    },
+    {
+      "id": "stone_discovery",
+      "name": "Stone Discovery",
+      "description": "A new stone deposit is found nearby.",
+      "effect": {
+        "stone": 30
+      },
+      "probability": 0.08
+    },
+    {
+      "id": "wandering_herbalist",
+      "name": "Wandering Herbalist",
+      "description": "A traveling herbalist shares some knowledge.",
+      "effect": {
+        "knowledge": 5
+      },
+      "probability": 0.05
+    },
+    {
+      "id": "heavy_rain",
+      "name": "Heavy Rain",
+      "description": "Heavy rain makes gathering more difficult but provides extra water.",
+      "effect": {
+        "water": 40,
+        "gatheringEfficiency": 0.8
+      },
+      "duration": 2,
+      "probability": 0.07
+    },
+    {
+      "id": "tool_breakthrough",
+      "name": "Tool Breakthrough",
+      "description": "Your people develop better tools, improving gathering efficiency.",
+      "effect": {
+        "gatheringEfficiency": 1.2
+      },
+      "duration": 3,
+      "probability": 0.06
+    },
+    {
+      "id": "drought",
+      "name": "Drought",
+      "description": "A severe drought reduces water supplies and slows gathering.",
+      "effect": {
+        "water": -30,
+        "gatheringEfficiency": 0.9
+      },
+      "duration": 3,
+      "probability": 0.05
+    },
+    {
+      "id": "bandit_raid",
+      "name": "Bandit Raid",
+      "description": "Bandits raid your settlement and steal resources.",
+      "effect": {
+        "food": -20,
+        "wood": -20
+      },
+      "probability": 0.04
+    },
+    {
+      "id": "traveling_merchant",
+      "name": "Traveling Merchant",
+      "description": "A wandering merchant offers useful supplies.",
+      "effect": {
+        "food": 20,
+        "stone": 20,
+        "knowledge": 2
+      },
+      "probability": 0.05
+    },
+    {
+      "id": "minor_earthquake",
+      "name": "Minor Earthquake",
+      "description": "An earthquake damages structures and costs some stone.",
+      "effect": {
+        "stone": -25
+      },
+      "probability": 0.03
+    },
+    {
+      "id": "blizzard",
+      "name": "Blizzard",
+      "description": "A raging blizzard slows your workers but provides extra water.",
+      "effect": {
+        "water": 20,
+        "gatheringEfficiency": 0.7
+      },
+      "duration": 2,
+      "probability": 0.04
+    },
+    {
+      "id": "heatwave",
+      "name": "Heatwave",
+      "description": "Scorching heat dries up water supplies and tires your workers.",
+      "effect": {
+        "water": -20,
+        "gatheringEfficiency": 0.85
+      },
+      "duration": 2,
+      "probability": 0.04
+    },
+    {
+      "id": "abandoned_cache",
+      "name": "Abandoned Cache",
+      "description": "You discover an abandoned supply cache filled with useful items.",
+      "effect": {
+        "food": 20,
+        "water": 20,
+        "knowledge": 3
+      },
+      "probability": 0.05
+    }
+  ],
+  "items": [
+    {
+      "id": "fire",
+      "name": "Fire",
+      "description": "Provides heat and light, enabling cooking and survival",
+      "history": "Controlled fire marked a key turning point, allowing early humans warmth, protection and cooked food.",
+      "craftingInfo": "Gather dry tinder and wood, then create a spark with flint stones or friction to ignite a lasting flame.",
+      "requirements": {
+        "wood": 2,
+        "knowledge": 1
+      },
+      "craftingTime": 15000,
+      "puzzle": "I dance and glow, giving warmth in the night. What am I?",
+      "puzzleAnswer": "fire",
+      "effect": {
+        "cookingUnlocked": true
+      },
+      "dependencies": []
+    },
+    {
+      "id": "knife",
+      "name": "Knife",
+      "description": "A basic tool for various tasks",
+      "history": "Knives are among humanity's oldest tools, first fashioned from flint or obsidian in the Stone Age.",
+      "craftingInfo": "Shape a sharp stone or metal blade and secure it to a sturdy handle using fiber or sinew.",
+      "requirements": {
+        "stone": 5,
+        "wood": 3,
+        "knowledge": 3
+      },
+      "craftingTime": 20000,
+      "puzzle": "I'm sharp and handy, cut and slice, in survival I'm worth my price.",
+      "puzzleAnswer": "knife",
+      "effect": {
+        "craftingEfficiencyMultiplier": 1.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "axe",
+      "name": "Axe",
+      "description": "Improves wood gathering efficiency",
+      "history": "Axes evolved from simple stone tools into metal-headed implements during the Bronze Age.",
+      "craftingInfo": "Bind a sharpened stone or metal head to a wooden handle, ensuring the head is secure for repeated swings.",
+      "requirements": {
+        "wood": 5,
+        "stone": 5,
+        "knowledge": 5
+      },
+      "craftingTime": 30000,
+      "puzzle": "What has a handle and a head, but no arms or legs?",
+      "puzzleAnswer": "axe",
+      "effect": {
+        "woodGatheringMultiplier": 2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "shelter",
+      "name": "Shelter",
+      "description": "Reduces resource consumption",
+      "history": "From simple caves to wooden huts, shelters have protected humans from the elements since prehistory.",
+      "craftingInfo": "Construct a basic frame from branches or wood and cover it with thatch, hide, or cloth to keep out the weather.",
+      "requirements": {
+        "wood": 10,
+        "stone": 5,
+        "knowledge": 3
+      },
+      "craftingTime": 60000,
+      "puzzle": "I keep you safe, I keep you dry, I'm built with care, up toward the sky. What am I?",
+      "puzzleAnswer": "shelter",
+      "effect": {
+        "resourceConsumptionMultiplier": 0.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "pickaxe",
+      "name": "Pickaxe",
+      "description": "Allows efficient stone and ore gathering",
+      "history": "Metal pickaxes enabled miners to extract valuable minerals from rock, a cornerstone of ancient industry.",
+      "craftingInfo": "Forge a pointed metal head and attach it firmly to a wooden handle to concentrate force on a small area.",
+      "requirements": {
+        "wood": 8,
+        "stone": 15,
+        "knowledge": 3
+      },
+      "craftingTime": 40000,
+      "puzzle": "I have a point and a rocky mission, breaking through stone is my ambition.",
+      "puzzleAnswer": "pickaxe",
+      "effect": {
+        "stoneGatheringMultiplier": 2,
+        "oreGatheringMultiplier": 1.5
+      },
+      "dependencies": [
+        "axe"
+      ]
+    },
+    {
+      "id": "farm",
+      "name": "Farm",
+      "description": "Produces food over time",
+      "history": "Early agriculture let humans settle and cultivate crops instead of roaming as hunter-gatherers.",
+      "craftingInfo": "Clear fertile land, till the soil and plant seeds in rows. Water and tend regularly for growth.",
+      "requirements": {
+        "wood": 15,
+        "stone": 10,
+        "knowledge": 10
+      },
+      "craftingTime": 120000,
+      "puzzle": "With seeds and soil, sun and rain, I help your food to grow again. What am I?",
+      "puzzleAnswer": "farm",
+      "effect": {
+        "foodProductionRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "well",
+      "name": "Well",
+      "description": "Produces water over time",
+      "history": "Wells have been dug since ancient times to reach groundwater and provide reliable supplies.",
+      "craftingInfo": "Dig deep and line the shaft with stone or wood to prevent collapse. Use a bucket or pulley to draw water.",
+      "requirements": {
+        "wood": 5,
+        "stone": 20,
+        "knowledge": 15
+      },
+      "craftingTime": 90000,
+      "puzzle": "Deep in the earth, I'm built with care, to bring up something vital and rare. What am I?",
+      "puzzleAnswer": "well",
+      "effect": {
+        "waterProductionRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "fishing_rod",
+      "name": "Fishing Rod",
+      "description": "Allows fishing, providing a new food source",
+      "history": "Simple rods with line and hook have helped humans harvest fish from rivers and seas for millennia.",
+      "craftingInfo": "Tie strong fiber to a flexible branch and attach a small bone or metal hook at the end to catch fish.",
+      "requirements": {
+        "wood": 5,
+        "fiber": 3
+      },
+      "craftingTime": 45000,
+      "puzzle": "I'm long and thin, with a hook at the end, I help you catch dinner, I'm your aquatic friend.",
+      "puzzleAnswer": "fishing rod",
+      "effect": {
+        "foodGatheringMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "kiln",
+      "name": "Kiln",
+      "description": "Allows creation of bricks and pottery",
+      "history": "Early potters used simple kilns to harden clay vessels, paving the way for durable storage and art.",
+      "craftingInfo": "Build an insulated chamber of stone or clay and maintain a hot fire inside to bake items placed within.",
+      "requirements": {
+        "stone": 20,
+        "clay": 10
+      },
+      "craftingTime": 90000,
+      "puzzle": "I'm hot inside, turning soft to hard, with me you can shape clay, I'm a crafter's card.",
+      "puzzleAnswer": "kiln",
+      "effect": {
+        "clayProcessingRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "loom",
+      "name": "Loom",
+      "description": "Allows creation of cloth for advanced crafting",
+      "history": "Looms revolutionized textile production in ancient civilizations by speeding up weaving.",
+      "craftingInfo": "Create a frame that holds warp threads under tension and pass a shuttle carrying weft threads over and under them.",
+      "requirements": {
+        "wood": 15,
+        "fiber": 10
+      },
+      "craftingTime": 75000,
+      "puzzle": "Threads intertwine, as I work back and forth, creating fabric fine, I prove my worth.",
+      "puzzleAnswer": "loom",
+      "effect": {
+        "fiberProcessingRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "forge",
+      "name": "Forge",
+      "description": "Allows metal working for advanced tools",
+      "history": "The development of forges enabled smiths to work iron and ushered in stronger tools and weapons.",
+      "craftingInfo": "Construct a hearth with bellows to intensify heat. Place metal inside until it glows and hammer it into shape.",
+      "requirements": {
+        "stone": 30,
+        "ore": 20,
+        "knowledge": 5
+      },
+      "craftingTime": 150000,
+      "puzzle": "Fire burns hot, metal bends to will, I shape the future, with hammer and skill.",
+      "puzzleAnswer": "forge",
+      "effect": {
+        "oreProcessingRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "herbalist_hut",
+      "name": "Herbalist's Hut",
+      "description": "Produces medicine, improving population health",
+      "history": "Traditional healers gathered plants in simple huts where remedies were prepared for the sick.",
+      "craftingInfo": "Build a small shelter with drying racks for herbs and a sturdy table to mix concoctions.",
+      "requirements": {
+        "wood": 20,
+        "herbs": 15,
+        "knowledge": 10
+      },
+      "craftingTime": 100000,
+      "puzzle": "Leaves and roots, I know their use, to heal the sick, my knowledge I produce.",
+      "puzzleAnswer": "herbalist's hut",
+      "effect": {
+        "medicineProductionRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "watchtower",
+      "name": "Watchtower",
+      "description": "Improves resource discovery rate",
+      "history": "From ancient walls to medieval forts, watchtowers helped communities spot danger approaching from afar.",
+      "craftingInfo": "Erect a tall framework of wood or stone with a sheltered platform at the top for lookouts.",
+      "requirements": {
+        "wood": 25,
+        "stone": 15
+      },
+      "craftingTime": 120000,
+      "puzzle": "I stand tall and see far, guarding day and night, from my peak, everything's in sight.",
+      "puzzleAnswer": "watchtower",
+      "effect": {
+        "resourceDiscoveryMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "storehouse",
+      "name": "Storehouse",
+      "description": "Increases resource storage capacity",
+      "history": "Communities built storehouses to keep food and goods dry and safe from animals and weather.",
+      "craftingInfo": "Construct sturdy walls and a solid roof, then add shelves or bins inside for organized storage.",
+      "requirements": {
+        "wood": 30,
+        "stone": 20
+      },
+      "craftingTime": 180000,
+      "puzzle": "Walls and roof, I keep things dry, your goods within, safe and spry.",
+      "puzzleAnswer": "storehouse",
+      "effect": {
+        "storageCapacityMultiplier": 2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "orchard",
+      "name": "Orchard",
+      "description": "Produces fruit over time",
+      "history": "Cultivated orchards allowed communities to harvest sweet produce season after season.",
+      "craftingInfo": "Plant young fruit trees in rows with space to grow and provide regular water and pruning.",
+      "requirements": {
+        "wood": 25,
+        "water": 20,
+        "fruit": 10
+      },
+      "craftingTime": 200000,
+      "puzzle": "Trees in rows, bearing sweet delight, I grow your food, from dawn to night.",
+      "puzzleAnswer": "orchard",
+      "effect": {
+        "fruitProductionRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "tannery",
+      "name": "Tannery",
+      "description": "Allows creation of leather for advanced crafting",
+      "history": "The process of tanning hides provided durable leather for clothing and equipment throughout history.",
+      "craftingInfo": "Soak animal hides, scrape them clean and treat with tannins from bark before stretching to dry.",
+      "requirements": {
+        "wood": 20,
+        "stone": 15,
+        "water": 10
+      },
+      "craftingTime": 150000,
+      "puzzle": "Hides I treat, with skill and care, turning skin to leather, strong and fair.",
+      "puzzleAnswer": "tannery",
+      "effect": {
+        "leatherProductionRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "library",
+      "name": "Library",
+      "description": "Increases knowledge generation",
+      "history": "Libraries preserved writings and allowed scholars to share ideas from ancient times onward.",
+      "craftingInfo": "Construct shelves to house scrolls and books and provide a quiet space for study and copying texts.",
+      "requirements": {
+        "wood": 30,
+        "stone": 20,
+        "knowledge": 15
+      },
+      "craftingTime": 240000,
+      "puzzle": "Words on pages, knowledge stored, in my halls, wisdom is explored.",
+      "puzzleAnswer": "library",
+      "effect": {
+        "knowledgeGenerationMultiplier": 2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "pottery_workshop",
+      "name": "Pottery Workshop",
+      "description": "Creates pottery for water storage and trading",
+      "requirements": {
+        "wood": 15,
+        "clay": 30,
+        "knowledge": 10
+      },
+      "craftingTime": 120000,
+      "puzzle": "With wheel and hand, I shape the clay, creating vessels for use each day.",
+      "puzzleAnswer": "pottery workshop",
+      "effect": {
+        "waterStorageMultiplier": 1.5,
+        "tradeGoodsProductionRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "hunting_lodge",
+      "name": "Hunting Lodge",
+      "description": "Improves food gathering from animals",
+      "requirements": {
+        "wood": 25,
+        "stone": 15,
+        "fiber": 10
+      },
+      "craftingTime": 150000,
+      "puzzle": "In forest deep, I track and stalk, to bring back meat, on which we'll not balk.",
+      "puzzleAnswer": "hunting lodge",
+      "effect": {
+        "meatGatheringMultiplier": 2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "quarry",
+      "name": "Quarry",
+      "description": "Increases stone and ore production",
+      "requirements": {
+        "wood": 20,
+        "stone": 30,
+        "knowledge": 15
+      },
+      "craftingTime": 180000,
+      "puzzle": "I dig deep into the mountain's heart, to bring forth riches, stone and ore to impart.",
+      "puzzleAnswer": "quarry",
+      "effect": {
+        "stoneProductionRate": 0.3,
+        "oreProductionRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "weaving_mill",
+      "name": "Weaving Mill",
+      "description": "Produces cloth more efficiently",
+      "requirements": {
+        "wood": 30,
+        "fiber": 40,
+        "knowledge": 20
+      },
+      "craftingTime": 210000,
+      "puzzle": "Shuttles fly, threads entwine, creating fabric, line by line.",
+      "puzzleAnswer": "weaving mill",
+      "effect": {
+        "clothProductionRate": 0.4
+      },
+      "dependencies": []
+    },
+    {
+      "id": "apothecary",
+      "name": "Apothecary",
+      "description": "Creates advanced medicines and increases population health",
+      "requirements": {
+        "wood": 25,
+        "herbs": 35,
+        "knowledge": 30
+      },
+      "craftingTime": 240000,
+      "puzzle": "Potions and tinctures, I brew with care, to cure the sick and health repair.",
+      "puzzleAnswer": "apothecary",
+      "effect": {
+        "medicineEffectivenessMultiplier": 2,
+        "populationHealthMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "marketplace",
+      "name": "Marketplace",
+      "description": "Allows trading and increases resource exchange efficiency",
+      "requirements": {
+        "wood": 40,
+        "stone": 30,
+        "knowledge": 25
+      },
+      "craftingTime": 300000,
+      "puzzle": "Goods are bought and sold with glee, in this place of commerce and trade you'll see.",
+      "puzzleAnswer": "marketplace",
+      "effect": {
+        "tradeEfficiencyMultiplier": 1.5,
+        "resourceExchangeRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "sawmill",
+      "name": "Sawmill",
+      "description": "Dramatically increases wood production",
+      "requirements": {
+        "wood": 50,
+        "stone": 30,
+        "ore": 20
+      },
+      "craftingTime": 270000,
+      "puzzle": "Blades whir and timber falls, transforming trees to planks for walls.",
+      "puzzleAnswer": "sawmill",
+      "effect": {
+        "woodProductionMultiplier": 3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "school",
+      "name": "School",
+      "description": "Increases knowledge generation and population skill",
+      "requirements": {
+        "wood": 40,
+        "stone": 40,
+        "knowledge": 50
+      },
+      "craftingTime": 360000,
+      "puzzle": "Young minds gather, to learn and grow, in this place of learning, knowledge to sow.",
+      "puzzleAnswer": "school",
+      "effect": {
+        "knowledgeGenerationMultiplier": 2.5,
+        "populationSkillMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "windmill",
+      "name": "Windmill",
+      "description": "Improves food production and introduces flour making",
+      "requirements": {
+        "wood": 45,
+        "stone": 35,
+        "fiber": 25
+      },
+      "craftingTime": 330000,
+      "puzzle": "My arms reach high, catching the breeze, grinding the grain with the greatest of ease.",
+      "puzzleAnswer": "windmill",
+      "effect": {
+        "foodProductionMultiplier": 2,
+        "flourProductionRate": 0.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "observatory",
+      "name": "Observatory",
+      "description": "Greatly enhances knowledge generation and unlocks advanced technologies",
+      "requirements": {
+        "stone": 60,
+        "ore": 40,
+        "knowledge": 75
+      },
+      "craftingTime": 480000,
+      "puzzle": "Gazing at stars, secrets unfold, in this tower of science, discoveries bold.",
+      "puzzleAnswer": "observatory",
+      "effect": {
+        "knowledgeGenerationMultiplier": 3,
+        "advancedTechUnlockRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "glassworks",
+      "name": "Glassworks",
+      "description": "Produces glass for advanced construction and tools",
+      "requirements": {
+        "stone": 50,
+        "wood": 30,
+        "sand": 100
+      },
+      "craftingTime": 360000,
+      "puzzle": "From sand to liquid, then cooled with care, I create clear panes beyond compare.",
+      "puzzleAnswer": "glassworks",
+      "effect": {
+        "glassProductionRate": 0.2,
+        "advancedConstructionEfficiency": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "brewery",
+      "name": "Brewery",
+      "description": "Produces beverages that boost worker morale and productivity",
+      "requirements": {
+        "wood": 40,
+        "water": 100,
+        "fruit": 50
+      },
+      "craftingTime": 300000,
+      "puzzle": "Bubbling vats and aging casks, I create drinks for all tasks.",
+      "puzzleAnswer": "brewery",
+      "effect": {
+        "workerMoraleBoost": 1.2,
+        "productivityMultiplier": 1.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "blacksmith",
+      "name": "Blacksmith",
+      "description": "Crafts metal tools and weapons, improving various gathering and crafting activities",
+      "requirements": {
+        "stone": 60,
+        "ore": 80,
+        "wood": 40
+      },
+      "craftingTime": 420000,
+      "puzzle": "With hammer and anvil, I shape the ore, creating tools not seen before.",
+      "puzzleAnswer": "blacksmith",
+      "effect": {
+        "toolEfficiencyMultiplier": 1.5,
+        "weaponCraftingRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "granary",
+      "name": "Granary",
+      "description": "Increases food storage capacity and reduces spoilage",
+      "requirements": {
+        "wood": 70,
+        "stone": 50,
+        "knowledge": 30
+      },
+      "craftingTime": 390000,
+      "puzzle": "Tall and round, I stand with pride, keeping the harvest safe inside.",
+      "puzzleAnswer": "granary",
+      "effect": {
+        "foodStorageMultiplier": 2,
+        "foodSpoilageReduction": 0.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "textile_mill",
+      "name": "Textile Mill",
+      "description": "Mass-produces textiles for clothing and trade",
+      "requirements": {
+        "wood": 60,
+        "stone": 40,
+        "fiber": 100
+      },
+      "craftingTime": 450000,
+      "puzzle": "Spinning wheels and clattering looms, I weave fine cloth in many rooms.",
+      "puzzleAnswer": "textile mill",
+      "effect": {
+        "textileProductionRate": 0.5,
+        "clothingQualityMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "scriptorium",
+      "name": "Scriptorium",
+      "description": "Produces books, increasing knowledge generation and preservation",
+      "requirements": {
+        "wood": 50,
+        "leather": 30,
+        "knowledge": 80
+      },
+      "craftingTime": 480000,
+      "puzzle": "Quills scratch and pages turn, preserving knowledge for all to learn.",
+      "puzzleAnswer": "scriptorium",
+      "effect": {
+        "knowledgePreservationRate": 0.3,
+        "researchSpeedMultiplier": 1.4
+      },
+      "dependencies": []
+    },
+    {
+      "id": "alchemist_lab",
+      "name": "Alchemist's Laboratory",
+      "description": "Conducts experiments, unlocking new resources and technologies",
+      "requirements": {
+        "stone": 70,
+        "glass": 40,
+        "knowledge": 100
+      },
+      "craftingTime": 540000,
+      "puzzle": "Bubbling flasks and smoky air, I seek truths both dark and fair.",
+      "puzzleAnswer": "alchemist's laboratory",
+      "effect": {
+        "resourceDiscoveryRate": 0.1,
+        "technologyAdvancementMultiplier": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "shipyard",
+      "name": "Shipyard",
+      "description": "Builds ships for fishing and trade, opening up new opportunities",
+      "requirements": {
+        "wood": 100,
+        "fiber": 60,
+        "ore": 40
+      },
+      "craftingTime": 600000,
+      "puzzle": "By river or sea, my creations sail free, bringing wealth from lands across the sea.",
+      "puzzleAnswer": "shipyard",
+      "effect": {
+        "fishingEfficiencyMultiplier": 2,
+        "tradeRouteCapacity": 3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "university",
+      "name": "University",
+      "description": "Greatly accelerates research and unlocks advanced technologies",
+      "requirements": {
+        "stone": 120,
+        "wood": 80,
+        "knowledge": 150
+      },
+      "craftingTime": 720000,
+      "puzzle": "Halls of learning, minds alight, I push the boundaries of wrong and right.",
+      "puzzleAnswer": "university",
+      "effect": {
+        "researchSpeedMultiplier": 3,
+        "advancedTechUnlockRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "monument",
+      "name": "Monument",
+      "description": "Increases population happiness and attracts new settlers",
+      "requirements": {
+        "stone": 200,
+        "ore": 100,
+        "knowledge": 120
+      },
+      "craftingTime": 900000,
+      "puzzle": "Towering high for all to see, I mark achievements of our society.",
+      "puzzleAnswer": "monument",
+      "effect": {
+        "populationHappinessMultiplier": 1.5,
+        "immigrationRate": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "irrigation_system",
+      "name": "Irrigation System",
+      "description": "Improves farm yields and water efficiency",
+      "requirements": {
+        "wood": 80,
+        "stone": 60,
+        "knowledge": 40
+      },
+      "craftingTime": 450000,
+      "puzzle": "Channels and pipes, I guide the flow, helping crops to thrive and grow.",
+      "puzzleAnswer": "irrigation system",
+      "effect": {
+        "farmYieldMultiplier": 1.5,
+        "waterEfficiencyMultiplier": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "lighthouse",
+      "name": "Lighthouse",
+      "description": "Improves fishing and trade ship safety",
+      "requirements": {
+        "stone": 150,
+        "glass": 50,
+        "knowledge": 70
+      },
+      "craftingTime": 600000,
+      "puzzle": "Tall I stand by waters deep, guiding ships while others sleep.",
+      "puzzleAnswer": "lighthouse",
+      "effect": {
+        "fishingSuccessRate": 1.4,
+        "tradeShipSafetyMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "paper_mill",
+      "name": "Paper Mill",
+      "description": "Produces paper for books and administration",
+      "requirements": {
+        "wood": 100,
+        "water": 80,
+        "knowledge": 50
+      },
+      "craftingTime": 480000,
+      "puzzle": "Pulp and press, sheets so fine, on me your words will soon align.",
+      "puzzleAnswer": "paper mill",
+      "effect": {
+        "paperProductionRate": 0.4,
+        "knowledgeEfficiencyMultiplier": 1.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "mint",
+      "name": "Mint",
+      "description": "Produces currency, enabling advanced economic systems",
+      "requirements": {
+        "stone": 120,
+        "ore": 100,
+        "knowledge": 80
+      },
+      "craftingTime": 720000,
+      "puzzle": "Metal discs I stamp with care, creating wealth beyond compare.",
+      "puzzleAnswer": "mint",
+      "effect": {
+        "currencyProductionRate": 0.2,
+        "tradeEfficiencyMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "aqueduct",
+      "name": "Aqueduct",
+      "description": "Improves water distribution and hygiene",
+      "requirements": {
+        "stone": 200,
+        "wood": 50,
+        "knowledge": 100
+      },
+      "craftingTime": 900000,
+      "puzzle": "Arches high, water flows, bringing life where'er it goes.",
+      "puzzleAnswer": "aqueduct",
+      "effect": {
+        "waterDistributionMultiplier": 2,
+        "populationHealthMultiplier": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "theater",
+      "name": "Theater",
+      "description": "Increases population happiness and cultural development",
+      "requirements": {
+        "wood": 150,
+        "stone": 100,
+        "cloth": 50
+      },
+      "craftingTime": 660000,
+      "puzzle": "On my stage, stories unfold, entertaining young and old.",
+      "puzzleAnswer": "theater",
+      "effect": {
+        "populationHappinessMultiplier": 1.4,
+        "culturalDevelopmentRate": 0.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "telescope",
+      "name": "Telescope",
+      "description": "Enhances astronomical research and navigation",
+      "requirements": {
+        "wood": 50,
+        "glass": 80,
+        "knowledge": 120
+      },
+      "craftingTime": 540000,
+      "puzzle": "Through me gaze at stars so far, unlocking secrets of what they are.",
+      "puzzleAnswer": "telescope",
+      "effect": {
+        "astronomicalResearchRate": 0.5,
+        "navigationEfficiencyMultiplier": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "printing_press",
+      "name": "Printing Press",
+      "description": "Mass-produces books, greatly accelerating knowledge spread",
+      "requirements": {
+        "wood": 80,
+        "ore": 100,
+        "knowledge": 150
+      },
+      "craftingTime": 780000,
+      "puzzle": "Letters arranged in lines so neat, I make copies quick and fleet.",
+      "puzzleAnswer": "printing press",
+      "effect": {
+        "bookProductionRate": 1,
+        "knowledgeSpreadMultiplier": 2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "music_hall",
+      "name": "Music Hall",
+      "description": "Enhances culture and provides entertainment",
+      "requirements": {
+        "wood": 120,
+        "stone": 80,
+        "cloth": 40
+      },
+      "craftingTime": 600000,
+      "puzzle": "Melodies and harmonies resound, bringing joy to all around.",
+      "puzzleAnswer": "music hall",
+      "effect": {
+        "culturalDevelopmentRate": 0.4,
+        "populationHappinessMultiplier": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "bank",
+      "name": "Bank",
+      "description": "Manages currency and enables loans",
+      "requirements": {
+        "stone": 180,
+        "ore": 100,
+        "knowledge": 130
+      },
+      "craftingTime": 840000,
+      "puzzle": "Gold and silver, notes and coins, I guard them well in secure loins.",
+      "puzzleAnswer": "bank",
+      "effect": {
+        "currencyManagementEfficiency": 1.5,
+        "loanAvailabilityRate": 0.2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "courthouse",
+      "name": "Courthouse",
+      "description": "Improves law and order, reducing crime",
+      "requirements": {
+        "stone": 160,
+        "wood": 100,
+        "knowledge": 140
+      },
+      "craftingTime": 720000,
+      "puzzle": "Justice served with balanced scales, here the law never fails.",
+      "puzzleAnswer": "courthouse",
+      "effect": {
+        "crimeReductionRate": 0.3,
+        "populationStabilityMultiplier": 1.4
+      },
+      "dependencies": []
+    },
+    {
+      "id": "factory",
+      "name": "Factory",
+      "description": "Enables mass production of goods",
+      "requirements": {
+        "stone": 200,
+        "ore": 150,
+        "knowledge": 180
+      },
+      "craftingTime": 1080000,
+      "puzzle": "Wheels turn and belts convey, producing goods day by day.",
+      "puzzleAnswer": "factory",
+      "effect": {
+        "goodsProductionMultiplier": 3,
+        "resourceConsumptionRate": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "hospital",
+      "name": "Hospital",
+      "description": "Greatly improves population health and lifespan",
+      "requirements": {
+        "stone": 220,
+        "wood": 150,
+        "knowledge": 200
+      },
+      "craftingTime": 1200000,
+      "puzzle": "In my wards, the sick find care, healing hands and knowledge rare.",
+      "puzzleAnswer": "hospital",
+      "effect": {
+        "populationHealthMultiplier": 2,
+        "lifespanIncreaseYears": 10
+      },
+      "dependencies": []
+    },
+    {
+      "id": "power_plant",
+      "name": "Power Plant",
+      "description": "Generates energy for advanced buildings and technologies",
+      "requirements": {
+        "stone": 250,
+        "ore": 200,
+        "knowledge": 220
+      },
+      "craftingTime": 1500000,
+      "puzzle": "Turbines spin with mighty force, providing power from nature's source.",
+      "puzzleAnswer": "power plant",
+      "effect": {
+        "energyProductionRate": 1,
+        "advancedTechEfficiencyMultiplier": 1.5
+      },
+      "dependencies": []
+    },
+    {
+      "id": "railway",
+      "name": "Railway",
+      "description": "Improves transportation and resource distribution",
+      "requirements": {
+        "wood": 180,
+        "ore": 250,
+        "knowledge": 190
+      },
+      "craftingTime": 1800000,
+      "puzzle": "On iron rails I swiftly glide, carrying goods from side to side.",
+      "puzzleAnswer": "railway",
+      "effect": {
+        "resourceDistributionMultiplier": 2,
+        "tradeEfficiencyMultiplier": 1.6
+      },
+      "dependencies": []
+    },
+    {
+      "id": "stock_exchange",
+      "name": "Stock Exchange",
+      "description": "Enables advanced economic transactions and investments",
+      "requirements": {
+        "stone": 280,
+        "glass": 150,
+        "knowledge": 250
+      },
+      "craftingTime": 1620000,
+      "puzzle": "Bulls and bears, they come and go, as numbers rise and fall in show.",
+      "puzzleAnswer": "stock exchange",
+      "effect": {
+        "economicGrowthRate": 0.5,
+        "investmentReturnMultiplier": 1.4
+      },
+      "dependencies": []
+    },
+    {
+      "id": "assembly_line",
+      "name": "Assembly Line",
+      "description": "Dramatically increases production efficiency",
+      "requirements": {
+        "ore": 300,
+        "wood": 200,
+        "knowledge": 280
+      },
+      "craftingTime": 2100000,
+      "puzzle": "Step by step, piece by piece, production speed I will increase.",
+      "puzzleAnswer": "assembly line",
+      "effect": {
+        "productionSpeedMultiplier": 3,
+        "resourceEfficiencyMultiplier": 1.3
+      },
+      "dependencies": []
+    },
+    {
+      "id": "research_lab",
+      "name": "Research Laboratory",
+      "description": "Conducts advanced scientific research",
+      "requirements": {
+        "stone": 250,
+        "glass": 200,
+        "knowledge": 300
+      },
+      "craftingTime": 1980000,
+      "puzzle": "In test tubes and under microscope, I seek answers and foster hope.",
+      "puzzleAnswer": "research laboratory",
+      "effect": {
+        "researchSpeedMultiplier": 2.5,
+        "breakthroughDiscoveryChance": 0.1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "metropolis",
+      "name": "Metropolis",
+      "description": "A grand city that provides numerous benefits",
+      "requirements": {
+        "stone": 500,
+        "wood": 400,
+        "knowledge": 350
+      },
+      "craftingTime": 3600000,
+      "puzzle": "Towers high and streets so wide, a bustling hub where millions reside.",
+      "puzzleAnswer": "metropolis",
+      "effect": {
+        "populationCapacityMultiplier": 5,
+        "economicOutputMultiplier": 3,
+        "culturalInfluenceMultiplier": 2
+      },
+      "dependencies": []
+    },
+    {
+      "id": "space_program",
+      "name": "Space Program",
+      "description": "Enables space exploration and advanced scientific discoveries",
+      "requirements": {
+        "ore": 600,
+        "fuel": 400,
+        "knowledge": 500
+      },
+      "craftingTime": 5400000,
+      "puzzle": "Beyond the sky, to stars we fly, in metal birds that pierce the sky.",
+      "puzzleAnswer": "space program",
+      "effect": {
+        "scientificDiscoveryRate": 2,
+        "resourceDiscoveryChance": 0.2,
+        "globalPrestigeMultiplier": 2
+      }
+    }
+  ]
+}

--- a/android/app/src/main/assets/www/prestige.js
+++ b/android/app/src/main/assets/www/prestige.js
@@ -1,0 +1,49 @@
+import { gameState } from './gameState.js';
+import { updateDisplay } from './ui.js';
+import { updateCraftableItems } from './crafting.js';
+import { updateAutomationControls } from './automation.js';
+
+export function calculatePrestigeGain() {
+    return Math.floor((gameState.knowledge || 0) / 100);
+}
+
+export function resetState() {
+    Object.assign(gameState, {
+        food: 100,
+        water: 100,
+        wood: 0,
+        stone: 0,
+        clay: 0,
+        fiber: 0,
+        ore: 0,
+        herbs: 0,
+        fruit: 0,
+        knowledge: 0,
+        population: 1,
+        workers: 0,
+        day: 1,
+        time: 0,
+        craftedItems: {},
+        automationAssignments: {},
+        availableWorkers: 0,
+        gatherCount: 0,
+        studyCount: 0,
+        craftCount: 0,
+        daysSinceGrowth: 0,
+        dailyFoodConsumed: 0,
+        dailyWaterConsumed: 0
+    });
+}
+
+export function prestigeGame() {
+    const gain = calculatePrestigeGain();
+    if (gain <= 0) {
+        alert('You need at least 100 knowledge to prestige.');
+        return;
+    }
+    gameState.prestigePoints = (gameState.prestigePoints || 0) + gain;
+    resetState();
+    updateCraftableItems();
+    updateAutomationControls();
+    updateDisplay();
+}

--- a/android/app/src/main/assets/www/resources.js
+++ b/android/app/src/main/assets/www/resources.js
@@ -1,0 +1,308 @@
+import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
+import { logEvent, updateDisplay, updateWorkingSection, showUnlockPuzzle } from './ui.js';
+import { checkAchievements } from './achievements.js';
+import { recordResourceGain } from './stats.js';
+import { updateAutomationControls } from './automation.js';
+import { updateCraftableItems, areDependenciesMet } from './crafting.js';
+
+export function getGatheringMultiplier(resource) {
+    return Object.values(gameState.craftedItems).reduce((mult, item) => {
+        if (item.effect) {
+            const key = `${resource}GatheringMultiplier`;
+            if (item.effect[key]) {
+                mult *= item.effect[key];
+            }
+        }
+        return mult;
+    }, 1);
+}
+
+
+export function gatherResource(resource) {
+    const config = getConfig();
+    if (gameState.availableWorkers === 0) {
+        logEvent("No available workers to gather resources.");
+        return;
+    }
+
+    const button = document.getElementById(`gather-${resource}`);
+    const progressBar = button.querySelector('.progress-bar');
+    
+    if (button.disabled) return;  // If already gathering, do nothing
+    
+    button.disabled = true;
+    adjustAvailableWorkers(-1);
+    gameState.currentWork = { type: 'gathering', resource: resource };
+    updateWorkingSection();
+
+    let progress = 0;
+    const interval = 100;  // Update every 100ms
+    const duration = getGatheringTime(resource);
+    
+    const progressInterval = setInterval(() => {
+        progress += interval;
+        const percentage = (progress / duration) * 100;
+        progressBar.style.width = `${percentage}%`;
+        
+        if (progress >= duration) {
+            clearInterval(progressInterval);
+            completeGathering(resource);
+            button.disabled = false;
+            progressBar.style.width = '0%';
+        }
+    }, interval);
+}
+
+export function getGatheringTime(resource) {
+    const config = getConfig();
+    let time = config.gatheringTimes[resource];
+    time /= getGatheringMultiplier(resource);
+    // Apply gathering efficiency modifier from events
+    time /= (gameState.gatheringEfficiency || 1);
+    const season = config.seasons[gameState.seasonIndex] || {};
+    if (season.gatheringEfficiency) {
+        time /= season.gatheringEfficiency;
+    }
+    // You can add more modifiers here based on other upgrades or skills
+    return time;
+}
+
+export function getGatheringRate(resource) {
+    return getGatheringMultiplier(resource) / (getGatheringTime(resource) / 1000);
+}
+
+export function scavenge() {
+    if (gameState.availableWorkers === 0) {
+        logEvent("No available workers to scavenge.");
+        return;
+    }
+
+    const button = document.getElementById('scavenge');
+    const progressBar = button.querySelector('.progress-bar');
+    if (button.disabled) return;
+
+    button.disabled = true;
+    adjustAvailableWorkers(-1);
+    gameState.currentWork = { type: 'scavenging' };
+    updateWorkingSection();
+
+    let progress = 0;
+    const interval = 100;
+    const duration = 4000;
+    const progressInterval = setInterval(() => {
+        progress += interval;
+        progressBar.style.width = `${(progress / duration) * 100}%`;
+        if (progress >= duration) {
+            clearInterval(progressInterval);
+            completeScavenge();
+            button.disabled = false;
+            progressBar.style.width = '0%';
+        }
+    }, interval);
+}
+
+function completeScavenge() {
+    const rewards = ['wood', 'stone', 'food', 'water'];
+    const resource = rewards[Math.floor(Math.random() * rewards.length)];
+    const amount = Math.round((Math.random() * 2 + 1) * getPrestigeMultiplier());
+    gameState[resource] = (gameState[resource] || 0) + amount;
+    recordResourceGain(resource, amount);
+    logEvent(`Scavenged ${amount} ${resource}.`);
+    adjustAvailableWorkers(1);
+    gameState.currentWork = null;
+    updateDisplay();
+    updateCraftableItems();
+    updateWorkingSection();
+    gameState.gatherCount += 1;
+    checkAchievements();
+}
+
+function completeGathering(resource) {
+    let amount = getGatheringMultiplier(resource);
+
+    // Apply gathering efficiency modifier
+    amount *= (gameState.gatheringEfficiency || 1);
+    amount *= getPrestigeMultiplier();
+    
+    // Round the amount to avoid fractional resources
+    amount = Math.round(amount);
+
+    gameState[resource] += amount;
+    recordResourceGain(resource, amount);
+    logEvent(`Gathered ${amount} ${resource}.`);
+
+    adjustAvailableWorkers(1);
+    gameState.currentWork = null;
+    
+    updateDisplay();
+    updateCraftableItems();
+    updateWorkingSection();
+    gameState.gatherCount += 1;
+    checkAchievements();
+}
+
+
+export function consumeResources(seconds = 1) {
+    const config = getConfig();
+    const dailyRate = gameState.craftedItems.shelter ? 0.5 : 1;
+    const season = config.seasons[gameState.seasonIndex] || {};
+    const ratePerSecond = (dailyRate * gameState.population) / config.constants.DAY_LENGTH;
+    const amount = ratePerSecond * seconds * (season.consumption || 1);
+
+    const foodConsumed = Math.min(gameState.food, amount);
+    const waterConsumed = Math.min(gameState.water, amount);
+
+    gameState.food -= foodConsumed;
+    gameState.water -= waterConsumed;
+
+    gameState.dailyFoodConsumed += foodConsumed;
+    gameState.dailyWaterConsumed += waterConsumed;
+}
+
+export function logDailyConsumption() {
+    logEvent(`Consumed ${gameState.dailyFoodConsumed.toFixed(1)} food and ${gameState.dailyWaterConsumed.toFixed(1)} water for the day.`);
+    gameState.dailyFoodConsumed = 0;
+    gameState.dailyWaterConsumed = 0;
+}
+
+
+export function produceResources() {
+    const mult = getPrestigeMultiplier();
+    const season = getConfig().seasons[gameState.seasonIndex] || {};
+    if (gameState.craftedItems.farm) {
+        const base = gameState.craftedItems.farm.effect.foodProductionRate;
+        const foodProduced = base * (gameState.automationAssignments.farm || 0) * mult * (season.production || 1);
+        gameState.food += foodProduced;
+        recordResourceGain('food', foodProduced);
+        logEvent(`Farm produced ${foodProduced.toFixed(1)} food.`);
+    }
+    if (gameState.craftedItems.well) {
+        const baseW = gameState.craftedItems.well.effect.waterProductionRate;
+        const waterProduced = baseW * (gameState.automationAssignments.well || 0) * mult * (season.production || 1);
+        gameState.water += waterProduced;
+        recordResourceGain('water', waterProduced);
+        logEvent(`Well produced ${waterProduced.toFixed(1)} water.`);
+    }
+    gameState.food = Math.min(gameState.food, 100);
+    gameState.water = Math.min(gameState.water, 100);
+    updateDisplay();
+}
+
+export function checkPopulationGrowth() {
+    const config = getConfig();
+    const threshold = config.constants.POPULATION_THRESHOLD;
+    if (
+        gameState.food >= threshold &&
+        gameState.water >= threshold &&
+        gameState.daysSinceGrowth >= config.constants.POPULATION_GROWTH_DAYS &&
+        gameState.gatherCount >= config.constants.POPULATION_GATHER_REQUIRED &&
+        gameState.studyCount >= config.constants.POPULATION_STUDY_REQUIRED &&
+        gameState.craftCount >= config.constants.POPULATION_CRAFT_REQUIRED
+    ) {
+        gameState.population += 1;
+        const cost = config.constants.POPULATION_GROWTH_COST;
+        gameState.food = Math.max(0, gameState.food - cost);
+        gameState.water = Math.max(0, gameState.water - cost);
+        logEvent("Your settlement has grown! Train newcomers to put them to work.");
+        gameState.gatherCount = 0;
+        gameState.studyCount = 0;
+        gameState.craftCount = 0;
+        gameState.daysSinceGrowth = 0;
+        updateAutomationControls();
+        updateDisplay();
+        checkAchievements();
+    }
+}
+
+export function trainWorker() {
+    if (gameState.population <= gameState.workers) {
+        logEvent("No untrained population available.");
+        return;
+    }
+    if (gameState.knowledge < 1) {
+        logEvent("Not enough knowledge to train a worker.");
+        return;
+    }
+    gameState.knowledge -= 1;
+    gameState.workers += 1;
+    adjustAvailableWorkers(1);
+    logEvent("Trained a new worker.");
+    updateAutomationControls();
+    updateDisplay();
+}
+
+function getKnowledgeGainMultiplier() {
+    return Object.values(gameState.craftedItems).reduce((mult, item) => {
+        if (item.effect && item.effect.knowledgeGenerationMultiplier) {
+            mult *= item.effect.knowledgeGenerationMultiplier;
+        }
+        return mult;
+    }, 1);
+}
+
+function getResearchSpeedMultiplier() {
+    return Object.values(gameState.craftedItems).reduce((mult, item) => {
+        if (item.effect && item.effect.researchSpeedMultiplier) {
+            mult *= item.effect.researchSpeedMultiplier;
+        }
+        return mult;
+    }, 1);
+}
+
+function getNextUnlockPuzzle() {
+    const config = getConfig();
+    const puzzle = config.unlockPuzzles.find(p => !gameState.unlockedFeatures.includes(p.unlocks));
+    if (puzzle) {
+        return puzzle;
+    }
+    const nextItem = config.items.find(item => !gameState.unlockedFeatures.includes(item.id) && areDependenciesMet(item));
+    if (nextItem) {
+        return {
+            id: `item_${nextItem.id}`,
+            puzzle: nextItem.puzzle,
+            answer: nextItem.puzzleAnswer,
+            unlocks: nextItem.id
+        };
+    }
+    return null;
+}
+
+export function study() {
+    if (gameState.availableWorkers === 0) {
+        logEvent("No available workers to study.");
+        return;
+    }
+
+    adjustAvailableWorkers(-1);
+    gameState.currentWork = { type: 'studying' };
+    updateWorkingSection();
+
+    const duration = 5000 / getResearchSpeedMultiplier();
+    let progress = 0;
+    const interval = 100;
+
+    const progressInterval = setInterval(() => {
+        progress += interval;
+        updateWorkingSection(progress / duration);
+
+        if (progress >= duration) {
+            clearInterval(progressInterval);
+            const knowledgeGain = 1 * getKnowledgeGainMultiplier();
+            gameState.knowledge += knowledgeGain;
+            logEvent(`Studied the book. Gained ${knowledgeGain.toFixed(1)} knowledge point${knowledgeGain !== 1 ? 's' : ''}.`);
+            adjustAvailableWorkers(1);
+            gameState.currentWork = null;
+            updateDisplay();
+
+            // Check if we should show an unlock puzzle
+            const nextUnlock = getNextUnlockPuzzle();
+            if (nextUnlock) {
+                showUnlockPuzzle(nextUnlock);
+            }
+            updateWorkingSection();
+            gameState.studyCount += 1;
+            updateDisplay();
+            checkAchievements();
+        }
+    }, interval); // Study time affected by research speed
+}

--- a/android/app/src/main/assets/www/stats.js
+++ b/android/app/src/main/assets/www/stats.js
@@ -1,0 +1,22 @@
+import { gameState } from './gameState.js';
+
+export function ensureStats() {
+    if (!gameState.stats) {
+        gameState.stats = { resourcesGathered: {}, itemsCrafted: {} };
+    }
+    if (!gameState.stats.resourcesGathered) gameState.stats.resourcesGathered = {};
+    if (!gameState.stats.itemsCrafted) gameState.stats.itemsCrafted = {};
+}
+
+export function recordResourceGain(resource, amount) {
+    if (amount <= 0) return;
+    ensureStats();
+    gameState.stats.resourcesGathered[resource] =
+        (gameState.stats.resourcesGathered[resource] || 0) + amount;
+}
+
+export function recordItemCraft(itemId) {
+    ensureStats();
+    gameState.stats.itemsCrafted[itemId] =
+        (gameState.stats.itemsCrafted[itemId] || 0) + 1;
+}

--- a/android/app/src/main/assets/www/styles.css
+++ b/android/app/src/main/assets/www/styles.css
@@ -1,0 +1,662 @@
+html, body {
+    font-family: Arial, sans-serif;
+    background-color: #1e1e2f;
+    color: #f5f5f5;
+    margin: 0;
+    padding: 0;
+    padding-top: 80px;
+    font-size: 16px;
+    overflow-x: hidden; /* Prevent unwanted horizontal scroll */
+}
+
+#loading-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #1e1e2f;
+    color: #ffffff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+h1, h2, h3 {
+    font-weight: 700;
+}
+
+p, li {
+    line-height: 1.6;
+}
+
+#game-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 20px;
+    width: 100%;
+    padding-bottom: 70px; /* space for bottom nav */
+    box-sizing: border-box; /* Include padding in width */
+}
+
+#top-section {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+    background-color: #1e1e2f;
+}
+
+#settings-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    cursor: pointer;
+    z-index: 101;
+}
+
+#settings-menu {
+    display: none;
+    position: fixed;
+    bottom: 110px;
+    right: 10px;
+    background-color: #34495e;
+    padding: 10px;
+    border-radius: 5px;
+    z-index: 1000;
+}
+
+
+h1, h2 {
+    text-align: center;
+    color: #e74c3c;
+}
+
+#day-night-cycle, #resources, #actions, #crafting, #knowledge, #automation {
+    background-color: #34495e;
+    border-radius: 5px;
+    margin-bottom: 20px;
+}
+
+#day-night-cycle {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0;
+}
+
+#population {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+}
+
+button {
+    background-color: #3498db;
+    border: none;
+    color: white;
+    padding: 10px 20px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 4px 2px;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #2980b9;
+}
+
+button:disabled {
+    background-color: #7f8c8d;
+    cursor: not-allowed;
+}
+
+#log {
+    background-color: #34495e;
+    border-radius: 5px;
+    padding: 10px;
+    height: 200px;
+    overflow-y: scroll;
+}
+
+#event-log {
+    list-style-type: none;
+    padding: 0;
+}
+
+#event-log li {
+    margin-bottom: 5px;
+}
+
+progress {
+    width: 100%;
+    height: 20px;
+}
+
+.popup {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #34495e;
+    padding: 20px;
+    border-radius: 5px;
+    z-index: 1000;
+}
+
+.highlight {
+    box-shadow: 0 0 10px 2px yellow;
+}
+
+.popup input {
+    width: 100%;
+    padding: 5px;
+    margin-top: 10px;
+}
+
+.popup button {
+    margin-top: 10px;
+}
+
+#event-popup {
+    min-width: 200px;
+    max-width: 300px;
+    text-align: center;
+    top: 10px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    font-size: 0.9rem;
+    padding: 10px;
+}
+
+#achievement-list {
+    list-style: none;
+    padding: 0;
+}
+
+#achievement-list li {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+}
+
+#population-progress {
+    margin-top: 10px;
+}
+
+#population-progress h3 {
+    margin: 0 0 5px 0;
+}
+
+.achievement-unlocked {
+    color: gold;
+}
+
+#achievement-popup {
+    min-width: 200px;
+    text-align: center;
+}
+
+.gather-action {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.progress-bar-container {
+    flex-grow: 1;
+    height: 20px;
+    background-color: #2c3e50;
+    margin-left: 10px;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.progress-bar {
+    width: 0;
+    height: 100%;
+    background-color: #27ae60;
+    transition: width 0.1s ease-in-out;
+}
+
+#book {
+    background-color: #34495e;
+    border-radius: 5px;
+    padding: 10px;
+    margin-bottom: 20px;
+}
+
+#book-page {
+    min-height: 120px;
+}
+
+.book-nav {
+    margin-top: 10px;
+}
+
+#book-nav-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
+/* Progress bar overlay inside buttons */
+.progress-button {
+    position: relative;
+    overflow: hidden;
+    padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.progress-button .progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background-color: rgba(39, 174, 96, 0.5);
+    z-index: 0;
+}
+
+.progress-button span {
+    position: relative;
+    z-index: 1;
+}
+
+.progress-button .multiplier {
+    margin-left: 8px;
+}
+
+#crafting-queue {
+    margin-top: 10px;
+}
+
+.crafting-item {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.crafting-item .progress-bar-container {
+    flex-grow: 1;
+    height: 20px;
+    background-color: #2c3e50;
+    margin-left: 10px;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.crafting-item .progress-bar {
+    width: 0;
+    height: 100%;
+    background-color: #e67e22;
+    transition: width 0.1s linear;
+}
+
+
+.automation-control {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.automation-control button {
+    padding: 5px 10px;
+}
+
+#game-container h1 {
+    color: #ff6f61;
+}
+
+button {
+    background-color: #ff6f61;
+    color: #fff;
+}
+
+button:hover {
+    background-color: #ff3b2f;
+}
+
+#resources {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    background-color: #34495e;
+    padding: 10px;
+    border-radius: 8px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    gap: 10px;
+}
+
+.resource-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: #ffffff;
+    min-width: 60px;
+}
+
+.resource-item i {
+    font-size: 20px;
+    margin-bottom: 2px;
+}
+
+.resource-item progress {
+    width: 60px;
+    height: 8px;
+    margin-top: 2px;
+}
+progress {
+    width: 100%;
+    height: 25px;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+progress::-webkit-progress-bar {
+    background-color: #2c3e50;
+    border-radius: 5px;
+}
+
+progress::-webkit-progress-value {
+    background-color: #27ae60; /* Green color */
+    border-radius: 5px;
+}
+
+progress::-moz-progress-bar {
+    background-color: #27ae60;
+}
+
+#population {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.population-info {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.population-info i {
+    font-size: 24px;
+    color: #f39c12; /* Orange to stand out */
+}
+
+#population p {
+    margin: 0;
+    font-size: 1em;
+    color: #ecf0f1;
+    text-align: center;
+}
+.population-info {
+    position: relative;
+    cursor: pointer;
+}
+
+.population-info:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #34495e;
+    color: #ecf0f1;
+    padding: 5px;
+    border-radius: 5px;
+    white-space: nowrap;
+    z-index: 10;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.population-info:hover::after {
+    opacity: 1;
+}
+
+.requirements-list {
+    list-style: none;
+    padding: 0;
+    margin-top: 5px;
+    font-size: 0.8em;
+}
+
+.requirements-list li {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.divider {
+    border-top: 1px solid #7f8c8d;
+    margin: 10px 0;
+}
+#actions.game-section-active {
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* Two columns for better organization */
+    gap: 10px;
+    padding: 10px;
+    background-color: #34495e;
+    border-radius: 10px;
+    margin-bottom: 56px;
+    padding-top: 25px;
+}
+
+.action-card {
+    display: flex;
+    align-items: center;
+    background-color: #e74c3c;
+    border-radius: 8px;
+    padding: 10px;
+    color: white;
+    cursor: pointer;
+    transition: transform 0.2s ease-in-out, background-color 0.3s;
+}
+
+.action-card:hover {
+    background-color: #d35400;
+    transform: translateY(-5px);
+}
+
+.action-card:active {
+    transform: translateY(0);
+}
+
+.action-text {
+    margin: 0;
+    font-size: 1.1em;
+    flex-grow: 1;
+}
+
+.progress-bar-container {
+    flex-grow: 1;
+    height: 15px;
+    background-color: #2c3e50;
+    margin-left: 10px;
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+.progress-bar {
+    height: 100%;
+    background-color: #27ae60;
+    width: 0%;
+    transition: width 0.3s linear;
+}
+
+.game-section {
+    display: none;
+}
+
+.game-section.game-section-active {
+    display: block;
+}
+
+/* Bottom navigation */
+#bottom-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    background-color: #1e1e2f;
+    border-top: 1px solid #2c3e50;
+    z-index: 100;
+}
+
+#bottom-nav .nav-btn {
+    flex: 1;
+    padding: 8px 0;
+    border: none;
+    background: none;
+    color: #fff;
+    font-size: 0.8em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#bottom-nav .nav-btn i {
+    font-size: 20px;
+    margin-bottom: 2px;
+}
+
+#bottom-nav .nav-btn.active {
+    background-color: #34495e;
+}
+
+#day-night-cycle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
+#population {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+}
+
+.population-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  #day-night-cycle {
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+}
+
+#day-night-cycle span {
+  font-family: Arial, sans-serif;
+  font-size: 0.95rem;
+}
+#time-section {
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  align-items: center;
+}
+#time-emoji {
+  margin-bottom: .4rem;
+  font-size: 20px;
+}
+#time-area {
+  display: flex;
+}
+#time-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+#time-time {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+#time-season {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 0.2rem;
+}
+.population-info i {
+  font-size: 1.2rem;
+}
+
+#train-worker-btn {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+
+  border-radius: 3px;
+
+  cursor: pointer;
+
+}
+
+
+
+
+@media (max-width: 600px) {
+    body {
+        font-size: 14px;
+    }
+
+    #game-container {
+        padding: 0 10px;
+        padding-bottom: 70px;
+        padding-top: 42px;
+    }
+
+    #resources {
+        justify-content: space-between;
+        gap: 5px;
+    }
+
+    #actions.game-section-active {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    button {
+        width: 100%;
+        padding: 15px;
+        font-size: 1.1em;
+    }
+
+    #log {
+        height: 150px;
+    }
+
+    .gather-action {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .progress-bar-container {
+        margin-left: 0;
+        margin-top: 5px;
+        width: 100%;
+    }
+}

--- a/android/app/src/main/assets/www/tutorial.js
+++ b/android/app/src/main/assets/www/tutorial.js
@@ -1,0 +1,77 @@
+import { gameState } from './gameState.js';
+
+let currentStep = 0;
+
+const steps = [
+    { text: 'Welcome to the wasteland! This short tutorial will guide you through the basics.' },
+    {
+        text: 'First, gather some wood by pressing the "Gather Wood" button.',
+        check: () => gameState.wood > 0,
+        highlight: '#gather-wood'
+    },
+    {
+        text: 'Great! Now open the Book tab to study knowledge.',
+        check: () => document.getElementById('book').classList.contains('game-section-active'),
+        highlight: '#bottom-nav button[data-target="book"]'
+    },
+    {
+        text: 'Next, open the Crafting tab to craft useful items.',
+        check: () => document.getElementById('crafting').classList.contains('game-section-active'),
+        highlight: '#bottom-nav button[data-target="crafting"]'
+    },
+    { text: 'You\'re all set! Survive and rebuild civilization.', end: true }
+];
+
+export function startTutorial() {
+    const saved = Number(localStorage.getItem('tutorialStep') || '0');
+    currentStep = saved;
+    if (currentStep >= steps.length) return;
+    showStep();
+}
+
+export function nextStep() {
+    removeHighlights();
+    currentStep += 1;
+    localStorage.setItem('tutorialStep', currentStep);
+    if (currentStep >= steps.length) {
+        endTutorial();
+    } else {
+        showStep();
+    }
+}
+
+export function checkTutorialProgress() {
+    const step = steps[currentStep];
+    if (step && step.check && step.check()) {
+        nextStep();
+    }
+}
+
+function showStep() {
+    const overlay = document.getElementById('tutorial-overlay');
+    const textEl = document.getElementById('tutorial-text');
+    const step = steps[currentStep];
+    if (!step) return;
+    overlay.style.display = 'block';
+    textEl.textContent = step.text;
+    if (step.highlight) {
+        const el = document.querySelector(step.highlight);
+        if (el) el.classList.add('highlight');
+    }
+}
+
+function removeHighlights() {
+    document.querySelectorAll('.highlight').forEach(el => el.classList.remove('highlight'));
+}
+
+function endTutorial() {
+    const overlay = document.getElementById('tutorial-overlay');
+    overlay.style.display = 'none';
+    removeHighlights();
+}
+
+export function skipTutorial() {
+    currentStep = steps.length;
+    localStorage.setItem('tutorialStep', currentStep);
+    endTutorial();
+}

--- a/android/app/src/main/assets/www/ui.js
+++ b/android/app/src/main/assets/www/ui.js
@@ -1,0 +1,220 @@
+import { gameState, getConfig, getPrestigeMultiplier } from './gameState.js';
+import { updateCraftableItems } from './crafting.js';
+import { getGatheringMultiplier } from './resources.js';
+
+export function updateDisplay() {
+    document.getElementById('food').textContent = Math.floor(gameState.food);
+    document.getElementById('water').textContent = Math.floor(gameState.water);
+    document.getElementById('wood').textContent = Math.floor(gameState.wood);
+    document.getElementById('stone').textContent = Math.floor(gameState.stone);
+    document.getElementById('knowledge').textContent = Math.floor(gameState.knowledge);
+    document.getElementById('clay').textContent = Math.floor(gameState.clay);
+    document.getElementById('fiber').textContent = Math.floor(gameState.fiber);
+    document.getElementById('ore').textContent = Math.floor(gameState.ore);
+    document.getElementById('herbs').textContent = Math.floor(gameState.herbs);
+    document.getElementById('fruit').textContent = Math.floor(gameState.fruit);
+    document.getElementById('food-bar').value = gameState.food;
+    document.getElementById('water-bar').value = gameState.water;
+    document.getElementById('population-count').textContent = gameState.population;
+    document.getElementById('available-workers').textContent = gameState.availableWorkers;
+    document.getElementById('total-workers').textContent = gameState.workers;
+    document.getElementById('day-count').textContent = gameState.day;
+    const config = getConfig();
+    const seasonName = config.seasons[gameState.seasonIndex].name;
+    const seasonEl = document.getElementById('current-season');
+    if (seasonEl) seasonEl.textContent = seasonName;
+    const prestigeEl = document.getElementById('prestige-points');
+    if (prestigeEl) prestigeEl.textContent = gameState.prestigePoints || 0;
+    updateGatherButtons();
+    updateGrowthIndicators();
+    updateStatsDisplay();
+}
+
+// Previously displayed current work progress. Section removed, so keep stub.
+export function updateWorkingSection() {}
+
+export function updateTimeDisplay() {
+    const config = getConfig();
+    const dayLength = config.constants.DAY_LENGTH;
+    const totalMinutes = (gameState.time / dayLength) * 1440;
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = Math.floor(totalMinutes % 60);
+    document.getElementById('time-display').textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+}
+
+export function updateTimeEmoji() {
+    const config = getConfig();
+    const dayLength = config.constants.DAY_LENGTH;
+    const totalHours = (gameState.time / dayLength) * 24;
+    const hours = Math.floor(totalHours);
+    const timeEmojiElement = document.getElementById('time-emoji');
+    if (hours >= 20 || hours < 6) {
+        timeEmojiElement.textContent = '🌙';
+    } else {
+        timeEmojiElement.textContent = '☀️';
+    }
+}
+
+export function logEvent(message) {
+    const eventLog = document.getElementById('event-log');
+    const li = document.createElement('li');
+    li.textContent = message;
+    eventLog.prepend(li);
+    if (eventLog.children.length > 5) {
+        eventLog.removeChild(eventLog.lastChild);
+    }
+}
+
+export function showEventPopup(event) {
+    const popup = document.getElementById('event-popup');
+    const nameEl = document.getElementById('event-name');
+    const descEl = document.getElementById('event-description');
+    nameEl.textContent = event.name;
+    descEl.textContent = event.description;
+    popup.style.display = 'block';
+    const config = getConfig();
+    const duration = event.duration ? event.duration * config.constants.DAY_LENGTH : 0;
+    const displaySeconds = Math.max(duration, 3);
+    if (popup._timeout) clearTimeout(popup._timeout);
+    popup._timeout = setTimeout(() => {
+        popup.style.display = 'none';
+    }, displaySeconds * 1000);
+}
+
+export function showUnlockPuzzle(puzzle) {
+    const puzzlePopup = document.getElementById('puzzle-popup');
+    document.getElementById('puzzle-title').textContent = 'Unlock New Feature';
+    document.getElementById('puzzle-description').textContent = puzzle.puzzle;
+    document.getElementById('puzzle-answer').value = '';
+    puzzlePopup.style.display = 'block';
+    puzzlePopup.dataset.puzzleId = puzzle.id;
+}
+
+export function submitUnlockPuzzleAnswer() {
+    const config = getConfig();
+    const puzzlePopup = document.getElementById('puzzle-popup');
+    const puzzleId = puzzlePopup.dataset.puzzleId;
+    let unlock = null;
+    let correctAnswer = '';
+    let puzzle = config.unlockPuzzles.find(p => p.id === puzzleId);
+    if (puzzle) {
+        unlock = puzzle.unlocks;
+        correctAnswer = puzzle.answer.toLowerCase();
+    } else {
+        const itemId = puzzleId.replace('item_', '');
+        const item = config.items.find(i => i.id === itemId);
+        if (item) {
+            unlock = item.id;
+            correctAnswer = item.puzzleAnswer.toLowerCase();
+        }
+    }
+
+    const answer = document.getElementById('puzzle-answer').value.toLowerCase();
+
+    if (unlock && answer === correctAnswer) {
+        gameState.unlockedFeatures.push(unlock);
+        logEvent(`Unlocked: ${unlock}!`);
+        puzzlePopup.style.display = 'none';
+        updateCraftableItems();
+    } else {
+        alert('Incorrect answer. Try again!');
+    }
+}
+
+export function closePuzzlePopup() {
+    document.getElementById('puzzle-popup').style.display = 'none';
+}
+
+export function openSettingsMenu() {
+    document.getElementById('settings-menu').style.display = 'block';
+}
+
+export function closeSettingsMenu() {
+    document.getElementById('settings-menu').style.display = 'none';
+}
+
+export function updateGatherButtons() {
+    const config = getConfig();
+    config.resources.forEach(resource => {
+        const button = document.getElementById(`gather-${resource}`);
+        if (!button) return;
+        let multiplierSpan = button.querySelector('.multiplier');
+        if (!multiplierSpan) {
+            multiplierSpan = document.createElement('span');
+            multiplierSpan.className = 'multiplier';
+            button.appendChild(multiplierSpan);
+        }
+        const mult = getGatheringMultiplier(resource) * getPrestigeMultiplier();
+        multiplierSpan.textContent = mult > 1 ? `x${mult}` : '';
+    });
+}
+
+export function updateGrowthIndicators() {
+    const config = getConfig();
+    const list = document.getElementById('growth-requirements');
+    if (!list) return;
+    const threshold = config.constants.POPULATION_THRESHOLD;
+    const items = [
+        { met: gameState.food >= threshold, text: `Food \u2265 ${threshold}` },
+        { met: gameState.water >= threshold, text: `Water \u2265 ${threshold}` },
+        {
+            met: gameState.daysSinceGrowth >= config.constants.POPULATION_GROWTH_DAYS,
+            text: `Days ${gameState.daysSinceGrowth}/${config.constants.POPULATION_GROWTH_DAYS}`
+        },
+        {
+            met: gameState.gatherCount >= config.constants.POPULATION_GATHER_REQUIRED,
+            text: `Gather ${gameState.gatherCount}/${config.constants.POPULATION_GATHER_REQUIRED}`
+        },
+        {
+            met: gameState.studyCount >= config.constants.POPULATION_STUDY_REQUIRED,
+            text: `Study ${gameState.studyCount}/${config.constants.POPULATION_STUDY_REQUIRED}`
+        },
+        {
+            met: gameState.craftCount >= config.constants.POPULATION_CRAFT_REQUIRED,
+            text: `Craft ${gameState.craftCount}/${config.constants.POPULATION_CRAFT_REQUIRED}`
+        }
+    ];
+
+    list.innerHTML = '';
+    items.forEach(req => {
+        const li = document.createElement('li');
+        li.textContent = `${req.met ? '✅' : '❌'} ${req.text}`;
+        list.appendChild(li);
+    });
+}
+
+export function updateStatsDisplay() {
+    const container = document.getElementById('stats-content');
+    if (!container) return;
+    const stats = gameState.stats || { resourcesGathered: {}, itemsCrafted: {} };
+    container.innerHTML = '';
+
+    const dayP = document.createElement('p');
+    dayP.textContent = `Days Survived: ${gameState.day}`;
+    container.appendChild(dayP);
+
+    const resHeader = document.createElement('h3');
+    resHeader.textContent = 'Resources Gathered';
+    container.appendChild(resHeader);
+    const resList = document.createElement('ul');
+    Object.entries(stats.resourcesGathered).forEach(([res, amt]) => {
+        const li = document.createElement('li');
+        li.textContent = `${res}: ${Math.floor(amt)}`;
+        resList.appendChild(li);
+    });
+    container.appendChild(resList);
+
+    const itemHeader = document.createElement('h3');
+    itemHeader.textContent = 'Items Crafted';
+    container.appendChild(itemHeader);
+    const itemList = document.createElement('ul');
+    const config = getConfig();
+    Object.entries(stats.itemsCrafted).forEach(([id, count]) => {
+        const item = config.items.find(i => i.id === id);
+        const name = item ? item.name : id;
+        const li = document.createElement('li');
+        li.textContent = `${name}: ${count}`;
+        itemList.appendChild(li);
+    });
+    container.appendChild(itemList);
+}

--- a/android/app/src/main/java/com/example/afk/MainActivity.java
+++ b/android/app/src/main/java/com/example/afk/MainActivity.java
@@ -1,0 +1,16 @@
+package com.example.afk;
+
+import android.os.Bundle;
+import android.webkit.WebView;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class MainActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        WebView webView = new WebView(this);
+        webView.getSettings().setJavaScriptEnabled(true);
+        webView.loadUrl("file:///android_asset/www/index.html");
+        setContentView(webView);
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">AFK Game</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,3 @@
+<resources>
+    <style name="Theme.App" parent="Theme.AppCompat.Light.NoActionBar"/>
+</resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec gradle "$@"

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -1,0 +1,7 @@
+
+@echo off
+
+setlocal
+
+"%~dp0\gradle" %*
+

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = 'afk-android'

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "automation.js",
   "scripts": {
     "start": "http-server -o",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "http-server": "^14.1.1"
-  }
+  },
+  "type": "module"
 }

--- a/tests/gameState.test.js
+++ b/tests/gameState.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { gameState, getPrestigeMultiplier, adjustAvailableWorkers, setGameConfig } from '../gameState.js';
+
+// Setup minimal config for tests
+setGameConfig({});
+
+// Reset gameState before each test
+function resetState() {
+    for (const key of Object.keys(gameState)) {
+        if (typeof gameState[key] === 'number') {
+            gameState[key] = 0;
+        } else if (Array.isArray(gameState[key])) {
+            gameState[key] = [];
+        } else if (typeof gameState[key] === 'object') {
+            gameState[key] = {};
+        } else {
+            gameState[key] = null;
+        }
+    }
+}
+
+test('adjustAvailableWorkers respects limits', () => {
+    resetState();
+    gameState.workers = 5;
+    gameState.availableWorkers = 3;
+    adjustAvailableWorkers(-2);
+    assert.equal(gameState.availableWorkers, 1);
+    adjustAvailableWorkers(10);
+    assert.equal(gameState.availableWorkers, 5);
+});
+
+test('getPrestigeMultiplier uses prestige points and items', () => {
+    resetState();
+    gameState.prestigePoints = 5; // base multiplier 1 + 0.5 = 1.5
+    gameState.craftedItems = {
+        testItem: { effect: { globalPrestigeMultiplier: 2 } }
+    };
+    const mult = getPrestigeMultiplier();
+    assert.equal(mult, 3); // 1.5 * 2
+});

--- a/tests/prestige.test.js
+++ b/tests/prestige.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { gameState } from '../gameState.js';
+import { calculatePrestigeGain } from '../prestige.js';
+
+function reset() {
+    gameState.knowledge = 0;
+}
+
+test('calculatePrestigeGain floors result', () => {
+    reset();
+    gameState.knowledge = 150;
+    assert.equal(calculatePrestigeGain(), 1);
+    gameState.knowledge = 50;
+    assert.equal(calculatePrestigeGain(), 0);
+});

--- a/tests/resources.test.js
+++ b/tests/resources.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { gameState, setGameConfig } from '../gameState.js';
+import { getGatheringMultiplier, getGatheringTime } from '../resources.js';
+
+setGameConfig({
+    gatheringTimes: { wood: 1000 },
+    seasons: [{ gatheringEfficiency: 1 }]
+});
+
+test('getGatheringMultiplier sums effects', () => {
+    gameState.craftedItems = {
+        axe: { effect: { woodGatheringMultiplier: 2 } },
+        gloves: { effect: { woodGatheringMultiplier: 1.5 } }
+    };
+    const mult = getGatheringMultiplier('wood');
+    assert.equal(mult, 3);
+});
+
+test('getGatheringTime uses multipliers', () => {
+    gameState.craftedItems = {
+        axe: { effect: { woodGatheringMultiplier: 2 } }
+    };
+    gameState.gatheringEfficiency = 1;
+    gameState.seasonIndex = 0;
+    const time = getGatheringTime('wood');
+    assert.equal(time, 500); // 1000 / 2
+});


### PR DESCRIPTION
## Summary
- create a simple Android project using a WebView to load the existing game
- expose `setGameConfig` in `gameState.js`
- enable Node ESM and provide tests using the built in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c66cbc47c832088b576d370abb1c0