### PR TITLE
Fix study tracking from book puzzles

### DIFF
--- a/book.js
+++ b/book.js
@@ -1,5 +1,6 @@
 import { gameState, getConfig } from './gameState.js';
 import { updateDisplay } from './ui.js';
+import { checkPopulationGrowth } from './resources.js';
 import { updateCraftableItems } from './crafting.js';
 
 export function initBook() {
@@ -77,8 +78,10 @@ function submitAnswer() {
             gameState.unlockedFeatures.push(puzzle.unlocks);
         }
         gameState.knowledge += 1;
+        gameState.studyCount += 1;
         updateDisplay();
         updateCraftableItems();
+        checkPopulationGrowth();
         renderPage();
     } else {
         alert('Incorrect answer. Try again!');


### PR DESCRIPTION
## Summary
- ensure solving puzzles counts as studying
- update population growth after book study

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c69ddf8f08320a63fbc02209a0d16