### PR TITLE
Centralize resource handling

### DIFF
--- a/automation.js
+++ b/automation.js
@@ -1,6 +1,6 @@
 import { gameState, getConfig, adjustAvailableWorkers, getPrestigeMultiplier } from './gameState.js';
 import { updateDisplay, logEvent } from './ui.js';
-import { recordResourceGain } from './stats.js';
+import { addResource } from './resourceManager.js';
 
 export function updateAutomationControls() {
     const config = getConfig();
@@ -83,8 +83,7 @@ export function runAutomation(seconds = 1) {
             const mult = getPrestigeMultiplier();
             if (itemId.startsWith('gather_')) {
                 const resource = itemId.replace('gather_', '');
-                gameState[resource] = (gameState[resource] || 0) + count * mult;
-                recordResourceGain(resource, count * mult);
+                addResource(resource, count * mult);
                 logEvent(`Workers gathered ${count * mult} ${resource}.`);
             } else {
                 const item = config.items.find(i => i.id === itemId);
@@ -92,8 +91,7 @@ export function runAutomation(seconds = 1) {
                     Object.entries(item.effect).forEach(([key]) => {
                         if (key.endsWith('ProductionRate')) {
                             const resource = key.replace('ProductionRate', '');
-                            gameState[resource] = (gameState[resource] || 0) + count * mult;
-                            recordResourceGain(resource, count * mult);
+                            addResource(resource, count * mult);
                             if (resource === 'food' || resource === 'water') {
                                 gameState[resource] = Math.min(100, gameState[resource]);
                             }

--- a/book.js
+++ b/book.js
@@ -2,6 +2,7 @@ import { gameState, getConfig } from './gameState.js';
 import { updateDisplay } from './ui.js';
 import { checkPopulationGrowth } from './resources.js';
 import { updateCraftableItems } from './crafting.js';
+import { addResource } from './resourceManager.js';
 
 export function initBook() {
     gameState.currentBookIndex = 0;
@@ -77,7 +78,7 @@ function submitAnswer() {
         if (!gameState.unlockedFeatures.includes(puzzle.unlocks)) {
             gameState.unlockedFeatures.push(puzzle.unlocks);
         }
-        gameState.knowledge += 1;
+        addResource('knowledge', 1);
         gameState.studyCount += 1;
         updateDisplay();
         updateCraftableItems();

--- a/crafting.js
+++ b/crafting.js
@@ -3,6 +3,7 @@ import { logEvent, updateDisplay, updateWorkingSection } from './ui.js';
 import { checkAchievements } from './achievements.js';
 import { updateAutomationControls } from './automation.js';
 import { recordItemCraft } from './stats.js';
+import { subtractResource } from './resourceManager.js';
 
 const craftingQueue = [];
 
@@ -42,7 +43,7 @@ function startCrafting(item) {
     // Deduct resources except knowledge, which is not consumed
     Object.entries(item.requirements).forEach(([resource, amount]) => {
         if (resource !== 'knowledge') {
-            gameState[resource] -= amount;
+            subtractResource(resource, amount);
         }
     });
 
@@ -124,7 +125,7 @@ function craftItem(item) {
     // and should never decrease.
     Object.entries(item.requirements).forEach(([resource, amount]) => {
         if (resource !== 'knowledge') {
-            gameState[resource] -= amount;
+            subtractResource(resource, amount);
         }
     });
     gameState.craftedItems[item.id] = item;

--- a/events.js
+++ b/events.js
@@ -1,6 +1,6 @@
 import { gameState, getConfig } from './gameState.js';
 import { logEvent, updateDisplay, showEventPopup } from './ui.js';
-import { recordResourceGain } from './stats.js';
+import { changeResource } from './resourceManager.js';
 
 let activeEvents = [];
 
@@ -19,8 +19,7 @@ function triggerEvent(event) {
 
     Object.entries(event.effect).forEach(([key, value]) => {
         if (key in gameState) {
-            gameState[key] += value;
-            if (value > 0) recordResourceGain(key, value);
+            changeResource(key, value);
         } else if (key === 'gatheringEfficiency') {
             // Store the efficiency modifier
             gameState.gatheringEfficiency = (gameState.gatheringEfficiency || 1) * value;

--- a/expeditions.js
+++ b/expeditions.js
@@ -1,6 +1,6 @@
 import { gameState, getConfig, adjustAvailableWorkers } from './gameState.js';
 import { logEvent } from './ui.js';
-import { recordResourceGain } from './stats.js';
+import { addResource } from './resourceManager.js';
 import { triggerRandomEvent } from './events.js';
 
 export function initExpeditions() {
@@ -33,8 +33,7 @@ function completeExpedition() {
         const rewards = config.resources;
         const resource = rewards[Math.floor(Math.random() * rewards.length)];
         const amount = Math.round(Math.random() * 5 + 5);
-        gameState[resource] = (gameState[resource] || 0) + amount;
-        recordResourceGain(resource, amount);
+        addResource(resource, amount);
         logEvent(`Expedition returned with ${amount} ${resource}.`);
     }
 }

--- a/game.js
+++ b/game.js
@@ -8,7 +8,7 @@ import { checkForEvents, updateActiveEvents, advanceEventTime, hasActiveEvents }
 import { initBook } from './book.js';
 import { initAchievements } from './achievements.js';
 import { startTutorial, checkTutorialProgress, nextStep, skipTutorial } from './tutorial.js';
-import { recordResourceGain } from './stats.js';
+import { addResource } from './resourceManager.js';
 import { initExpeditions, updateExpeditions, hasExpeditions } from './expeditions.js';
 
 function saveGame(manual = false) {
@@ -48,8 +48,7 @@ function applyOfflineProgress() {
         if (itemId.startsWith('gather_')) {
             const resource = itemId.replace('gather_', '');
             const gained = count * cycles * mult;
-            gameState[resource] = (gameState[resource] || 0) + gained;
-            recordResourceGain(resource, gained);
+            addResource(resource, gained);
         } else {
             const item = config.items.find(i => i.id === itemId);
             if (item && item.effect) {
@@ -57,8 +56,7 @@ function applyOfflineProgress() {
                     if (key.endsWith('ProductionRate')) {
                         const resource = key.replace('ProductionRate', '');
                         const gained = count * cycles * mult;
-                        gameState[resource] = (gameState[resource] || 0) + gained;
-                        recordResourceGain(resource, gained);
+                        addResource(resource, gained);
                         if (resource === 'food' || resource === 'water') {
                             gameState[resource] = Math.min(100, gameState[resource]);
                         }

--- a/resourceManager.js
+++ b/resourceManager.js
@@ -1,0 +1,25 @@
+import { gameState } from './gameState.js';
+import { recordResourceGain } from './stats.js';
+
+export function changeResource(resource, amount) {
+    if (!Object.prototype.hasOwnProperty.call(gameState, resource)) {
+        gameState[resource] = 0;
+    }
+    gameState[resource] += amount;
+    if (amount > 0) {
+        recordResourceGain(resource, amount);
+    }
+    return gameState[resource];
+}
+
+export function addResource(resource, amount) {
+    return changeResource(resource, amount);
+}
+
+export function subtractResource(resource, amount) {
+    return changeResource(resource, -amount);
+}
+
+export function getResource(resource) {
+    return gameState[resource] || 0;
+}


### PR DESCRIPTION
## Summary
- add `resourceManager.js` with helper methods for adjusting resources
- refactor resource logic in various modules to use the new manager

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c6aac693883208551999a593797db