### PR TITLE
Adjust gathering times for new day length

### DIFF
--- a/knowledge_data.json
+++ b/knowledge_data.json
@@ -54,15 +54,15 @@
     "DAYS_PER_SEASON": 10
   },
   "gatheringTimes": {
-    "wood": 5000,
-    "stone": 7000,
-    "food": 3000,
-    "water": 2000,
-    "clay": 6000,
-    "fiber": 4000,
-    "ore": 8000,
-    "herbs": 5000,
-    "fruit": 4000
+    "wood": 50000,
+    "stone": 70000,
+    "food": 30000,
+    "water": 20000,
+    "clay": 60000,
+    "fiber": 40000,
+    "ore": 80000,
+    "herbs": 50000,
+    "fruit": 40000
   },
   "seasons": [
     { "name": "Spring", "gatheringEfficiency": 1.1, "consumption": 1, "production": 1.1 },

--- a/resources.js
+++ b/resources.js
@@ -55,7 +55,9 @@ export function gatherResource(resource) {
 
 export function getGatheringTime(resource) {
     const config = getConfig();
-    let time = config.gatheringTimes[resource];
+    const baseTime = config.gatheringTimes[resource];
+    const dayScale = config.constants.DAY_LENGTH / 600;
+    let time = baseTime * dayScale;
     time /= getGatheringMultiplier(resource);
     // Apply gathering efficiency modifier from events
     time /= (gameState.gatheringEfficiency || 1);


### PR DESCRIPTION
## Summary
- slow down manual gathering times
- scale gathering times with the configured day length

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ca3ac34288320b671a6a4458174f2