### PR TITLE
Fix automation safety and queue handling

### DIFF
--- a/automation.js
+++ b/automation.js
@@ -8,7 +8,11 @@ export function updateAutomationControls() {
     automationControlsContainer.innerHTML = '';
 
     config.items.forEach(item => {
-        if (gameState.craftedItems[item.id] && (item.effect.foodProductionRate || item.effect.waterProductionRate)) {
+        if (
+            gameState.craftedItems[item.id] &&
+            item.effect &&
+            (item.effect.foodProductionRate || item.effect.waterProductionRate)
+        ) {
             const div = document.createElement('div');
             div.className = 'automation-control';
             div.innerHTML = `

--- a/crafting.js
+++ b/crafting.js
@@ -5,8 +5,6 @@ import { updateAutomationControls } from './automation.js';
 import { recordItemCraft } from './stats.js';
 import { subtractResource } from './resourceManager.js';
 
-const craftingQueue = [];
-
 export function updateCraftableItems() {
     if (!gameState.unlockedFeatures.includes('crafting')) {
         document.getElementById('crafting').style.display = 'none';
@@ -105,7 +103,7 @@ function completeCrafting(item) {
 function updateCraftingQueue() {
     const queueContainer = document.getElementById('crafting-queue');
     queueContainer.innerHTML = '';
-    craftingQueue.forEach(craftingItem => {
+    gameState.craftingQueue.forEach(craftingItem => {
         const itemElement = document.createElement('div');
         itemElement.className = 'crafting-item';
         itemElement.innerHTML = `


### PR DESCRIPTION
## Summary
- guard against items without effects in automation controls
- remove unused `craftingQueue` array and reference `gameState.craftingQueue` when rendering the queue

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ca8b477748320998aab20f0b41957